### PR TITLE
Fix build to unblock yarn link in dev environment

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -13,9 +13,6 @@
     "decimal.js": "^10.3.1",
     "tiny-invariant": "^1.2.0"
   },
-  "resolutions": {
-    "@solana/web3.js": "1.43.1"
-  },
   "devDependencies": {
     "@types/bn.js": "~5.1.0",
     "@types/decimal.js": "^7.4.0",
@@ -25,6 +22,7 @@
     "eslint-config-prettier": "^8.3.0",
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
+    "process": "^0.11.10",
     "ts-jest": "^27.0.3",
     "typescript": "^4.5.5"
   },

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "0.1.8",
-    "decimal.js": "^10.3.1",
+    "decimal.js": "~10.4.1",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "0.1.8",
-    "decimal.js": "~10.4.1",
+    "decimal.js": "~10.3.1",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/common-sdk/tsconfig-base.json
+++ b/packages/common-sdk/tsconfig-base.json
@@ -11,7 +11,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "node"
   },
   "exclude": ["./dist/**/*"],
   "references": [

--- a/packages/common-sdk/tsconfig-base.json
+++ b/packages/common-sdk/tsconfig-base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "ES6",
     "allowJs": false,
     "declaration": true,
     "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2016.Array.Include"],
@@ -10,8 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "moduleResolution": "Node"
   },
   "exclude": ["./dist/**/*"],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,7 +1371,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
-decimal.js@*, decimal.js@^10.2.1, decimal.js@^10.3.1:
+decimal.js@*, decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@~10.3.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,6 +2840,11 @@ pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,11 @@ decimal.js@*, decimal.js@^10.2.1, decimal.js@^10.3.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
+decimal.js@~10.4.1:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
+  integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"


### PR DESCRIPTION
- Changing to ES6 build so webpack 5 can resolve paths correctly if this package is yarn linked
- Add `process` to this build as webpack 5 cannot resolve polyfills correctly when yarn linked.
- Remove forced resolution of web3.js

## Testing
- Did a yarn link on my local environment. Errors are gone.