### PR TITLE
Allow option to take in blockhash for TransactionBuilder.txnSize

### DIFF
--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -117,11 +117,11 @@ export class TransactionBuilder {
    * @returns the size of the current transaction in bytes.
    * @throws error if transaction is over maximum package size.
    */
-  async txnSize() {
+  async txnSize(options: BuildOptions = { latestBlockhash: undefined }) {
     if (this.isEmpty()) {
       return 0;
     }
-    const request = await this.build();
+    const request = await this.build(options);
     return request.transaction.serialize({ requireAllSignatures: false }).length;
   }
 


### PR DESCRIPTION
- add an option to allow TransactionBuilder.txnSize to serialize a transaction with an existing blockhash
- otherwise, a loop calling txnSize will be extremely slow due to the on-chain call.
- 