### PR TITLE
revert module type and decimal.js requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ jspm_packages/
 .npmrc
 .vscode/
 dist/
-
+.DS_store

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",
@@ -10,7 +10,7 @@
   "dependencies": {
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "0.1.8",
-    "decimal.js": "~10.3.1",
+    "decimal.js": "^10.3.1",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/common-sdk/tsconfig-base.json
+++ b/packages/common-sdk/tsconfig-base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "ES6",
+    "module": "commonjs",
     "allowJs": false,
     "declaration": true,
     "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2016.Array.Include"],


### PR DESCRIPTION
## issues
- cannot import common-sdk property (with whirlpools-sdk@0.5.3)
https://app.asana.com/0/1202413563699470/1203428880059392/f
- both decimal.js@10.4.2 and decimal.js@10.3.1 are installed and are treated as different types.

## changes
- update version "0.1.2" to "0.1.3"
- revert module type "es6" to "commonjs"
- revert decimal.js version requirement "~10.3.1" to "^10.3.1"
- add .DS_store to .gitignore