### PR TITLE
Fix: reject owner changed ATA

### DIFF
--- a/packages/common-sdk/src/web3/ata-util.ts
+++ b/packages/common-sdk/src/web3/ata-util.ts
@@ -97,6 +97,12 @@ export async function resolveOrCreateATAs(
       const ataAddress = nonNativeAddresses[index]!;
       let resolvedInstruction;
       if (tokenAccount) {
+        // ATA whose owner has been changed is abnormal entity.
+        // To prevent to send swap/withdraw/collect output to the ATA, an error should be thrown.
+        if (!tokenAccount.owner.equals(ownerAddress)) {
+          throw new Error(`ATA with change of ownership detected: ${ataAddress.toBase58()}`);
+        }
+
         resolvedInstruction = { address: ataAddress, ...EMPTY_INSTRUCTION };
       } else {
         const createAtaInstruction = createAssociatedTokenAccountInstruction(


### PR DESCRIPTION
Preventing to send the output of swap to an ATA whose owner is changed.
Since the owner changed ATAs are abnormal entities, throws an error if it is detected.

``npm run test`` passed.