### PR TITLE
Adding GetAccount request utils and ParsableEntity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 lerna-debug.log*
 node_modules/
 jspm_packages/
+test-ledger/
 .npmrc
 .vscode/
 dist/

--- a/packages/common-sdk/src/web3/index.ts
+++ b/packages/common-sdk/src/web3/index.ts
@@ -1,6 +1,6 @@
 export * from "./address-util";
 export * from "./ata-util";
+export * from "./network";
 export * from "./public-key-utils";
 export * from "./token-util";
 export * from "./transactions";
-

--- a/packages/common-sdk/src/web3/network/account-requests.ts
+++ b/packages/common-sdk/src/web3/network/account-requests.ts
@@ -53,6 +53,6 @@ export async function getMultipleAccounts(
   }
 
   const combinedResult = (await Promise.all(responses)).flat();
-  invariant(combinedResult.length === addresses.length, "bulkRequest not enough results");
+  invariant(combinedResult.length === addresses.length, "getMultipleAccounts not enough results");
   return combinedResult;
 }

--- a/packages/common-sdk/src/web3/network/account-requests.ts
+++ b/packages/common-sdk/src/web3/network/account-requests.ts
@@ -1,8 +1,17 @@
 import { Address } from "@project-serum/anchor";
-import { Connection, AccountInfo, PublicKey } from "@solana/web3.js";
+import { Connection, AccountInfo } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import { AddressUtil } from "../address-util";
 import { ParsableEntity } from "./parsing";
+
+export async function getParsedAccount<T>(
+  connection: Connection,
+  address: Address,
+  parser: ParsableEntity<T>
+): Promise<T | null> {
+  const value = await connection.getAccountInfo(AddressUtil.toPubKey(address));
+  return parser.parse(value?.data);
+}
 
 export async function getMultipleParsedAccounts<T>(
   connection: Connection,

--- a/packages/common-sdk/src/web3/network/bulk-requests.ts
+++ b/packages/common-sdk/src/web3/network/bulk-requests.ts
@@ -1,0 +1,46 @@
+import { Address } from "@project-serum/anchor";
+import { Connection, AccountInfo, PublicKey } from "@solana/web3.js";
+import invariant from "tiny-invariant";
+import { AddressUtil } from "../address-util";
+import { ParsableEntity } from "./parsing";
+
+export async function getMultipleParsedAccounts<T>(
+  connection: Connection,
+  addresses: Address[],
+  parser: ParsableEntity<T>
+): Promise<(T | null)[]> {
+  if (addresses.length === 0) {
+    return [];
+  }
+
+  const values = await getMultipleAccounts(connection, AddressUtil.toPubKeys(addresses));
+  const results = values
+    .map((value) => parser.parse(value?.data))
+    .filter((value): value is T | null => value !== undefined);
+  invariant(results.length === addresses.length, "not enough results fetched");
+  return results;
+}
+
+type GetMultipleAccountsInfoResponse = (AccountInfo<Buffer> | null)[];
+
+export async function getMultipleAccounts(
+  connection: Connection,
+  addresses: PublicKey[]
+): Promise<GetMultipleAccountsInfoResponse> {
+  if (addresses.length === 0) {
+    return [];
+  }
+
+  const responses: Promise<GetMultipleAccountsInfoResponse>[] = [];
+  const chunk = 100; // getMultipleAccounts has limitation of 100 accounts per request
+
+  for (let i = 0; i < addresses.length; i += chunk) {
+    const addressesSubset = addresses.slice(i, i + chunk);
+    const res = connection.getMultipleAccountsInfo(addressesSubset, connection.commitment);
+    responses.push(res);
+  }
+
+  const combinedResult = (await Promise.all(responses)).flat();
+  invariant(combinedResult.length === addresses.length, "bulkRequest not enough results");
+  return combinedResult;
+}

--- a/packages/common-sdk/src/web3/network/bulk-requests.ts
+++ b/packages/common-sdk/src/web3/network/bulk-requests.ts
@@ -25,7 +25,7 @@ type GetMultipleAccountsInfoResponse = (AccountInfo<Buffer> | null)[];
 
 export async function getMultipleAccounts(
   connection: Connection,
-  addresses: PublicKey[]
+  addresses: Address[]
 ): Promise<GetMultipleAccountsInfoResponse> {
   if (addresses.length === 0) {
     return [];
@@ -35,8 +35,11 @@ export async function getMultipleAccounts(
   const chunk = 100; // getMultipleAccounts has limitation of 100 accounts per request
 
   for (let i = 0; i < addresses.length; i += chunk) {
-    const addressesSubset = addresses.slice(i, i + chunk);
-    const res = connection.getMultipleAccountsInfo(addressesSubset, connection.commitment);
+    const addressChunk = addresses.slice(i, i + chunk);
+    const res = connection.getMultipleAccountsInfo(
+      AddressUtil.toPubKeys(addressChunk),
+      connection.commitment
+    );
     responses.push(res);
   }
 

--- a/packages/common-sdk/src/web3/network/index.ts
+++ b/packages/common-sdk/src/web3/network/index.ts
@@ -1,0 +1,2 @@
+export * from "./bulk-requests";
+export * from "./parsing";

--- a/packages/common-sdk/src/web3/network/index.ts
+++ b/packages/common-sdk/src/web3/network/index.ts
@@ -1,2 +1,2 @@
-export * from "./bulk-requests";
+export * from "./account-requests";
 export * from "./parsing";

--- a/packages/common-sdk/src/web3/network/parsing.ts
+++ b/packages/common-sdk/src/web3/network/parsing.ts
@@ -1,0 +1,80 @@
+import { PublicKey } from "@solana/web3.js";
+import { AccountInfo, MintInfo, MintLayout, u64 } from "@solana/spl-token";
+import { TokenUtil } from "../token-util";
+
+/**
+ * Static abstract class definition to parse entities.
+ * @category Parsables
+ */
+export interface ParsableEntity<T> {
+  /**
+   * Parse account data
+   *
+   * @param accountData Buffer data for the entity
+   * @returns Parsed entity
+   */
+  parse: (accountData: Buffer | undefined | null) => T | null;
+}
+
+/**
+ * @category Parsables
+ */
+@staticImplements<ParsableEntity<AccountInfo>>()
+export class ParsableTokenAccountInfo {
+  private constructor() {}
+
+  public static parse(data: Buffer | undefined | null): AccountInfo | null {
+    if (!data) {
+      return null;
+    }
+
+    try {
+      return TokenUtil.deserializeTokenAccount(data);
+    } catch (e) {
+      console.error(`error while parsing TokenAccount: ${e}`);
+      return null;
+    }
+  }
+}
+
+/**
+ * @category Parsables
+ */
+@staticImplements<ParsableEntity<MintInfo>>()
+export class ParsableMintInfo {
+  private constructor() {}
+
+  public static parse(data: Buffer | undefined | null): MintInfo | null {
+    if (!data) {
+      return null;
+    }
+
+    try {
+      const buffer = MintLayout.decode(data);
+      const mintInfo: MintInfo = {
+        mintAuthority:
+          buffer.mintAuthorityOption === 0 ? null : new PublicKey(buffer.mintAuthority),
+        supply: u64.fromBuffer(buffer.supply),
+        decimals: buffer.decimals,
+        isInitialized: buffer.isInitialized !== 0,
+        freezeAuthority:
+          buffer.freezeAuthority === 0 ? null : new PublicKey(buffer.freezeAuthority),
+      };
+
+      return mintInfo;
+    } catch (e) {
+      console.error(`error while parsing MintInfo: ${e}`);
+      return null;
+    }
+  }
+}
+
+/**
+ * Class decorator to define an interface with static methods
+ * Reference: https://github.com/Microsoft/TypeScript/issues/13462#issuecomment-295685298
+ */
+export function staticImplements<T>() {
+  return <U extends T>(constructor: U) => {
+    constructor;
+  };
+}

--- a/packages/common-sdk/src/web3/network/parsing.ts
+++ b/packages/common-sdk/src/web3/network/parsing.ts
@@ -61,7 +61,7 @@ export class ParsableMintInfo {
         decimals: buffer.decimals,
         isInitialized: buffer.isInitialized !== 0,
         freezeAuthority:
-          buffer.freezeAuthority === 0 ? null : new PublicKey(buffer.freezeAuthority),
+          buffer.freezeAuthorityOption === 0 ? null : new PublicKey(buffer.freezeAuthority),
       };
 
       return mintInfo;

--- a/packages/common-sdk/src/web3/network/parsing.ts
+++ b/packages/common-sdk/src/web3/network/parsing.ts
@@ -50,6 +50,9 @@ export class ParsableMintInfo {
     }
 
     try {
+      if (data.byteLength !== MintLayout.span) {
+        throw new Error("Invalid data length for MintInfo");
+      }
       const buffer = MintLayout.decode(data);
       const mintInfo: MintInfo = {
         mintAuthority:

--- a/packages/common-sdk/src/web3/token-util.ts
+++ b/packages/common-sdk/src/web3/token-util.ts
@@ -1,4 +1,11 @@
-import { AccountInfo, AccountLayout, NATIVE_MINT, Token, TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
+import {
+  AccountInfo,
+  AccountLayout,
+  NATIVE_MINT,
+  Token,
+  TOKEN_PROGRAM_ID,
+  u64,
+} from "@solana/spl-token";
 import { Connection, PublicKey, SystemProgram } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import { ZERO } from "../math";
@@ -8,7 +15,6 @@ import { deriveATA, Instruction, resolveOrCreateATA } from "../web3";
  * @category Util
  */
 export class TokenUtil {
-
   public static isNativeMint(mint: PublicKey) {
     return mint.equals(NATIVE_MINT);
   }
@@ -16,6 +22,10 @@ export class TokenUtil {
   public static deserializeTokenAccount = (data: Buffer | undefined): AccountInfo | null => {
     if (!data) {
       return null;
+    }
+
+    if (data.byteLength !== AccountLayout.span) {
+      throw new Error("Invalid data length for TokenAccount");
     }
 
     const accountInfo = AccountLayout.decode(data);
@@ -83,13 +93,13 @@ export class TokenUtil {
       const sendSolTxn = SystemProgram.transfer({
         fromPubkey: sourceWallet,
         toPubkey: destinationWallet,
-        lamports: BigInt(amount.toString())
-      })
+        lamports: BigInt(amount.toString()),
+      });
       return {
         instructions: [sendSolTxn],
         cleanupInstructions: [],
-        signers: []
-      }
+        signers: [],
+      };
     }
 
     const sourceTokenAccount = await deriveATA(sourceWallet, tokenMint);

--- a/packages/common-sdk/tests/test-context.ts
+++ b/packages/common-sdk/tests/test-context.ts
@@ -1,0 +1,45 @@
+import { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { Wallet } from "@project-serum/anchor";
+import { Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+export const DEFAULT_RPC_ENDPOINT_URL = "http://localhost:8899";
+
+export interface TestContext {
+  connection: Connection;
+  wallet: Wallet;
+}
+
+export function createTestContext(url: string = DEFAULT_RPC_ENDPOINT_URL): TestContext {
+  return {
+    connection: new Connection(url, "confirmed"),
+    wallet: new Wallet(Keypair.generate()),
+  };
+}
+
+export async function requestAirdrop(ctx: TestContext, numSol: number = 1000): Promise<void> {
+  const signature = await ctx.connection.requestAirdrop(
+    ctx.wallet.publicKey,
+    numSol * LAMPORTS_PER_SOL
+  );
+  const latestBlockhash = await ctx.connection.getLatestBlockhash();
+  await ctx.connection.confirmTransaction({ signature, ...latestBlockhash });
+}
+
+export function createNewMint(ctx: TestContext): Promise<Token> {
+  return Token.createMint(
+    ctx.connection,
+    ctx.wallet.payer,
+    ctx.wallet.publicKey,
+    ctx.wallet.publicKey,
+    6,
+    TOKEN_PROGRAM_ID
+  );
+}
+
+export async function createAssociatedTokenAccount(
+  ctx: TestContext,
+  mint?: PublicKey
+): Promise<{ ata: PublicKey; mint: PublicKey }> {
+  let tokenMint = mint || (await createNewMint(ctx)).publicKey;
+  const token = new Token(ctx.connection, tokenMint, TOKEN_PROGRAM_ID, ctx.wallet.payer);
+  return { ata: await token.createAssociatedTokenAccount(ctx.wallet.publicKey), mint: tokenMint };
+}

--- a/packages/common-sdk/tests/web3/network/account-requests.test.ts
+++ b/packages/common-sdk/tests/web3/network/account-requests.test.ts
@@ -1,0 +1,58 @@
+import { Keypair } from "@solana/web3.js";
+import { MintInfo } from "@solana/spl-token";
+import { getMultipleParsedAccounts, getParsedAccount, ParsableMintInfo } from "../../../src/web3";
+import {
+  createAssociatedTokenAccount,
+  createNewMint,
+  createTestContext,
+  requestAirdrop,
+} from "../../test-context";
+
+jest.setTimeout(100 * 1000 /* ms */);
+
+describe("account-requests", () => {
+  const ctx = createTestContext();
+
+  beforeAll(async () => {
+    await requestAirdrop(ctx);
+  });
+
+  it("getParsedAccount, ok", async () => {
+    const mint = await createNewMint(ctx);
+    const expected = await mint.getMintInfo();
+    const mintInfo = await getParsedAccount(ctx.connection, mint.publicKey, ParsableMintInfo);
+    expectMintInfoEquals(mintInfo!, expected);
+  });
+
+  it("getMultipleParsedAccounts, some null", async () => {
+    const mint = await createNewMint(ctx);
+    const missing = Keypair.generate().publicKey;
+    const mintInfos = await getMultipleParsedAccounts(
+      ctx.connection,
+      [mint.publicKey, missing],
+      ParsableMintInfo
+    );
+    expectMintInfoEquals(mintInfos[0]!, await mint.getMintInfo());
+    expect(mintInfos[1]).toBeNull();
+  });
+
+  it("getMultipleParsedAccounts, invalid type returns null", async () => {
+    const mint = await createNewMint(ctx);
+    const { ata } = await createAssociatedTokenAccount(ctx, mint.publicKey);
+    const mintInfos = await getMultipleParsedAccounts(
+      ctx.connection,
+      [mint.publicKey, ata],
+      ParsableMintInfo
+    );
+    expectMintInfoEquals(mintInfos[0]!, await mint.getMintInfo());
+    expect(mintInfos[1]).toBeNull();
+  });
+});
+
+function expectMintInfoEquals(actual: MintInfo, expected: MintInfo) {
+  expect(actual.decimals).toEqual(expected.decimals);
+  expect(actual.isInitialized).toEqual(expected.isInitialized);
+  expect(actual.mintAuthority!.equals(expected.mintAuthority!)).toBeTruthy();
+  expect(actual.freezeAuthority!.equals(expected.freezeAuthority!)).toBeTruthy();
+  expect(actual.supply.eq(expected.supply)).toBeTruthy();
+}

--- a/packages/common-sdk/tests/web3/network/parsing.test.ts
+++ b/packages/common-sdk/tests/web3/network/parsing.test.ts
@@ -1,0 +1,30 @@
+import { ParsableTokenAccountInfo } from "../../../src/web3";
+import {
+  createAssociatedTokenAccount,
+  createTestContext,
+  requestAirdrop,
+} from "../../test-context";
+
+jest.setTimeout(100 * 1000 /* ms */);
+
+describe("parsing", () => {
+  const ctx = createTestContext();
+
+  beforeAll(async () => {
+    await requestAirdrop(ctx);
+  });
+
+  it("ParsableTokenAccountInfo", async () => {
+    const { ata, mint } = await createAssociatedTokenAccount(ctx);
+    const account = await ctx.connection.getAccountInfo(ata);
+    const parsed = ParsableTokenAccountInfo.parse(account!.data);
+
+    expect(parsed).toBeDefined();
+    if (!parsed) {
+      throw new Error("parsed is undefined");
+    }
+    expect(parsed.mint.equals(mint)).toBeTruthy();
+    expect(parsed.isInitialized).toEqual(true);
+    expect(parsed.amount.eqn(0)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
- Porting over generic `ParsableEntity` from `whirlpools-sdk` - https://github.com/orca-so/whirlpools/blob/main/sdk/src/network/public/parsing.ts#L19
- Adding utility methods for making bulk requests for getting Solana `AccountInfo` objects and parsing them
