### PR TITLE
Add AddressUtil.toString methods

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.1.13",
+  "version": "0.1.12",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/address-util.ts
+++ b/packages/common-sdk/src/web3/address-util.ts
@@ -18,6 +18,14 @@ export class AddressUtil {
     return addresses.map((address) => AddressUtil.toPubKey(address));
   }
 
+  public static toString(address: Address): string {
+    return AddressUtil.toPubKey(address).toBase58();
+  }
+
+  public static toStrings(addresses: Address[]): string[] {
+    return addresses.map((address) => AddressUtil.toString(address));
+  }
+
   public static findProgramAddress(seeds: (Uint8Array | Buffer)[], programId: PublicKey): PDA {
     const [publicKey, bump] = utils.publicKey.findProgramAddressSync(seeds, programId);
     return { publicKey, bump };


### PR DESCRIPTION
- Add new toString & toStrings methods to AddressUtil to allow easy conversion from Address to string.