### PR TITLE
fix TransactionBuilder.txnSize

### DIFF
--- a/packages/common-sdk/README.md
+++ b/packages/common-sdk/README.md
@@ -9,5 +9,5 @@ solana-test-validator
 
 In the common-sdk folder, run:
 ```
-npm run test
+yarn run test --verbose
 ```

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/constants.ts
+++ b/packages/common-sdk/src/web3/transactions/constants.ts
@@ -1,8 +1,10 @@
+import { PACKET_DATA_SIZE } from "@solana/web3.js";
+
 // The hard-coded limit of a transaction size in bytes
-export const TX_SIZE_LIMIT = 1232;
+export const TX_SIZE_LIMIT = PACKET_DATA_SIZE; // 1232
 
 // The hard-coded limit of an encoded transaction size in bytes
-export const TX_BASE64_ENCODED_SIZE_LIMIT = 1644;
+export const TX_BASE64_ENCODED_SIZE_LIMIT = Math.ceil(TX_SIZE_LIMIT / 3) * 4; // 1644
 
 // A dummy blockhash to use for measuring transaction sizes
 export const MEASUREMENT_BLOCKHASH = {

--- a/packages/common-sdk/tests/web3/ata-util.test.ts
+++ b/packages/common-sdk/tests/web3/ata-util.test.ts
@@ -21,7 +21,7 @@ describe("ata-util", () => {
     Token.getAssociatedTokenAddress(ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, mint, owner);
 
   beforeAll(async () => {
-    requestAirdrop(ctx);
+    await requestAirdrop(ctx);
   });
 
   it("resolveOrCreateATA, wrapped sol", async () => {

--- a/packages/common-sdk/tests/web3/transactions/constants.test.ts
+++ b/packages/common-sdk/tests/web3/transactions/constants.test.ts
@@ -1,0 +1,15 @@
+import { PACKET_DATA_SIZE } from "@solana/web3.js";
+import { TX_SIZE_LIMIT, TX_BASE64_ENCODED_SIZE_LIMIT } from "../../../src/web3";
+
+jest.setTimeout(100 * 1000 /* ms */);
+
+describe("transactions-constants", () => {
+  it("TX_SIZE_LIMIT", async () => {
+    expect(TX_SIZE_LIMIT).toEqual(1232);
+    expect(TX_SIZE_LIMIT).toEqual(PACKET_DATA_SIZE);
+  });
+
+  it("TX_BASE64_ENCODED_SIZE_LIMIT", async () => {
+    expect(TX_BASE64_ENCODED_SIZE_LIMIT).toEqual(1644);
+  });
+});

--- a/packages/common-sdk/tests/web3/transactions/transactions-builder.test.ts
+++ b/packages/common-sdk/tests/web3/transactions/transactions-builder.test.ts
@@ -1,0 +1,98 @@
+import {
+  Transaction,
+  VersionedTransaction,
+  TransactionInstruction,
+  SystemProgram,
+  Keypair,
+  TransactionMessage,
+} from "@solana/web3.js";
+import { defaultTransactionBuilderOptions, isVersionedTransaction, MEASUREMENT_BLOCKHASH, TransactionBuilder } from "../../../src/web3";
+import { createTestContext } from "../../test-context";
+import TestWallet from "../../utils/test-wallet";
+
+jest.setTimeout(100 * 1000 /* ms */);
+
+describe("transactions-builder", () => {
+  const ctx = createTestContext();
+
+  describe("txnSize", () => {
+    const buildTransactionBuilder = (transferIxNum: number, version: "legacy" | number) => {
+      const { wallet, connection } = ctx;
+
+      const ixs: TransactionInstruction[] = [];
+      for (let i=0; i < transferIxNum; i++) {
+        ixs.push(SystemProgram.transfer({
+          programId: SystemProgram.programId,
+          fromPubkey: wallet.publicKey,
+          lamports: 10_000_000,
+          toPubkey: Keypair.generate().publicKey,
+        }));
+      }
+
+      const builder = new TransactionBuilder(connection, wallet, {
+        ...defaultTransactionBuilderOptions,
+        defaultBuildOption: {
+          maxSupportedTransactionVersion: version,
+          latestBlockhash: MEASUREMENT_BLOCKHASH,
+          blockhashCommitment: "confirmed",
+        },
+      });
+
+      builder.addInstruction({
+        instructions: ixs,
+        cleanupInstructions: [],
+        signers: [],
+      });
+
+      return builder;
+    }
+
+    it("legacy: size < PACKET_DATA_SIZE", async () => {
+      const builder = buildTransactionBuilder(15, "legacy");
+
+      // should be legacy
+      const transaction = await builder.build();
+      expect(isVersionedTransaction(transaction.transaction)).toBeFalsy();
+
+      const size = builder.txnSize();
+      expect(size).toEqual(901);
+    });
+
+    it("legacy: size > PACKET_DATA_SIZE", async () => {
+      const builder = buildTransactionBuilder(22, "legacy");
+
+      // should be legacy
+      const transaction = await builder.build();
+      expect(isVersionedTransaction(transaction.transaction)).toBeFalsy();
+
+      // logical size: 1244 > PACKET_DATA_SIZE
+      expect(() => builder.txnSize()).toThrow(
+        /Unable to measure transaction size/
+      );
+    });
+
+    it("v0: size < PACKET_DATA_SIZE", async () => {
+      const builder = buildTransactionBuilder(15, 0);
+
+      // should be versioned
+      const transaction = await builder.build();
+      expect(isVersionedTransaction(transaction.transaction)).toBeTruthy();
+
+      const size = builder.txnSize();
+      expect(size).toEqual(903);
+    });
+
+    it("v0: size > PACKET_DATA_SIZE", async () => {
+      const builder = buildTransactionBuilder(22, 0);
+   
+      // should be versioned
+      const transaction = await builder.build();
+      expect(isVersionedTransaction(transaction.transaction)).toBeTruthy();
+      
+      // logical size: 1246 > PACKET_DATA_SIZE
+      expect(() => builder.txnSize()).toThrow(
+        /Unable to measure transaction size/
+      );
+    });
+  });
+});


### PR DESCRIPTION
## txnSize
``txnSize`` used to return serialized data size.
However now it returns the size of base64 encoded serialized data. (unintentional breaking change)

Once this PR is merged:
- same behavior for both Transaction and VersionedTransaction(V0)
- Return the size of the serialized data (not Base64 encoded)
- Maximum size is ``PACKET_DATA_SIZE`` (= ``TX_SIZE_LIMIT`` = 1232)
- Throw an exception if the maximum size is exceeded

## Test
Unit test cases for TransactionBuilder.txnSize and some constants are added.

## Bump to 0.2.2
This PR contains bump to 0.2.2