### PR TITLE
bump common-sdk

### DIFF
--- a/packages/orca-sdk/package.json
+++ b/packages/orca-sdk/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@orca-so/common-sdk": "0.2.1",
+    "@orca-so/common-sdk": "0.2.2",
     "@solana/web3.js": "^1.74.0",
     "axios": "^0.27.2",
     "decimal.js": "^10.3.1"


### PR DESCRIPTION
update orca-sdk to use common-sdk 0.2.2

I'll publish this commit as 0.1.0 of orca-sdk.
(0.1.0 have NOT been published yet)
https://www.npmjs.com/package/@orca-so/orca-sdk?activeTab=versions