### PR TITLE
Allow PDA as OwnerAddress / Add option to create WSOL account with CreateAccountWithSeed 

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2-beta.0",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",
@@ -23,11 +23,13 @@
     "jest": "^29.5.0",
     "prettier": "^2.3.2",
     "process": "^0.11.10",
+    "rimraf": "^4.1.2",
     "ts-jest": "^29.1.0",
     "typescript": "^4.5.5"
   },
   "scripts": {
-    "build": "tsc -p src",
+    "build": "rimraf dist && tsc -p src",
+    "clean": "rimraf dist",
     "watch": "tsc -w -p src",
     "prepublishOnly": "yarn build",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",

--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.3.2-beta.0",
+  "version": "0.3.2",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/tests/web3/network/simple-fetcher-impl.test.ts
+++ b/packages/common-sdk/tests/web3/network/simple-fetcher-impl.test.ts
@@ -33,7 +33,8 @@ describe("simple-account-fetcher", () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    // jest.resetAllMocks doesn't work (I guess that jest.spyOn rewrite prototype of Connection)
+    jest.restoreAllMocks();
   });
 
   describe("getAccount", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,6 +1498,16 @@
     decimal.js "^10.3.1"
     tiny-invariant "^1.2.0"
 
+"@orca-so/common-sdk@^0.3.0", "@orca-so/common-sdk@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.3.1.tgz#939232636b8888237981fad328ddb07a81decfa1"
+  integrity sha512-hk4wPdEBlugfJ2vBnap0P8bH/h/OX109s+NMPZT3CRmQX2IRaal/KBEHT/Gi3OuCG0JSPDvtiFKtXzHnScCt6A==
+  dependencies:
+    "@solana/spl-token" "^0.3.8"
+    "@solana/web3.js" "^1.75.0"
+    decimal.js "^10.3.1"
+    tiny-invariant "^1.2.0"
+
 "@orca-so/token-sdk@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@orca-so/token-sdk/-/token-sdk-0.1.5.tgz#a27c99e4ebd3dfc3fe3dbb8243b12911a717dfb2"


### PR DESCRIPTION
# Asana
parent: https://app.asana.com/0/1202413563699470/1204997759596564/f

subtask1: https://app.asana.com/0/0/1204997759596568/f
subtask2: https://app.asana.com/0/0/1204997759596569/f

# Overview of the changes
## add ``allowPDAOwnerAddress`` option to ``resolveOrCreateATA(s)``
``getAssociatedTokenAddressSync`` has ``allowOwnerOffCurve`` option and its default value is ``false``.
If ``allowOwnerOffCurve`` is set to ``false``, ``owner`` of ATA must be **NOT** PDA.

Multi-sig wallet makes owner a PDA. To allow use by multisig wallets, add an option to accept PDA for owner.

Although I considered always allowing this option, I decided to make it optional like spl-token to avoid unintentional use of PDA.

see also: [getAssociatedTokenAddressSync](https://solana-labs.github.io/solana-program-library/token/js/functions/getAssociatedTokenAddressSync.html)

## add ``wrappedSolAccountCreateMethod`` option to ``resolveOrCreateATA(s)``
its value is one of ["keypair", "withSeed"].
- keypair: Using Keypair.generate() in the conventional way
- withSeed: Using CreateAccountWithSeed ix with randomly generated 32-bytes seed string

Multi-sig wallets are incompatible with transactions requiring signatures other than the wallet address; the addition of withSeed, which does not use Keypair, will facilitate the use of multi-sig wallets.
