### PR TITLE
TokenRepository improvements

### DIFF
--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.1.6-beta.4",
+  "version": "0.1.6-beta.5",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.1.6-beta.6",
+  "version": "0.1.6-beta.7",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.1.6-beta.5",
+  "version": "0.1.6-beta.6",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/token-sdk/src/fetcher.ts
+++ b/packages/token-sdk/src/fetcher.ts
@@ -16,12 +16,14 @@ const TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 
 export class TokenFetcher {
   private readonly providers: MetadataProvider[] = [];
+  private readonly connection: Connection;
+  private readonly timeoutMs: number;
   private _cache: Map<string, Token> = new Map();
 
-  constructor(
-    private readonly connection: Connection,
-    private readonly timeoutMs: number = TIMEOUT_MS
-  ) {}
+  constructor(connection: Connection, timeoutMs: number = TIMEOUT_MS) {
+    this.connection = connection;
+    this.timeoutMs = timeoutMs;
+  }
 
   public setCache(cache: Map<string, Token>): TokenFetcher {
     this._cache = cache;

--- a/packages/token-sdk/src/repository.ts
+++ b/packages/token-sdk/src/repository.ts
@@ -122,14 +122,14 @@ export class TokenRepository {
   }
 
   /**
-   * Fetches token metadata and tags for a given mint.
-   * If the mint is excluded, null is returned.
-   * If the mint is not in the repository, null is returned.
+   * Augments the TokenFetcher fetch method with metadata from this repository instance. All tokens
+   * will be fetched, but the result will also include a flag indicating presence in this repository
+   * as well as additional metadata such as tags.
    *
    * @param fetcher TokenFetcher to use
    * @param mint Mint to get
    * @param refresh If true, fetches metadata from all providers. If false, uses cached metadata.
-   * @returns Token metadata and tags. Null if mint is excluded.
+   * @returns TokenResult containing metadata, tags, and flag indicating presence in this repo
    */
   async fetch(fetcher: TokenFetcher, mint: Address, refresh = false): Promise<TokenResult> {
     const token = await fetcher.find(mint, refresh);
@@ -137,14 +137,14 @@ export class TokenRepository {
   }
 
   /**
-   * Fetches token metadata and tags for the given mints that are in the repository.
-   * If a mint is excluded, it is not returned.
-   * If a mint is not in the repository, it is not returned.
+   * Augments the TokenFetcher fetchMany method with metadata from this repository instance. All
+   * tokens will be fetched, but the result will also include a flag indicating presence in this
+   * repository as well as additional metadata such as tags.
    *
    * @param fetcher TokenFetcher to use
    * @param mints Mints to get
    * @param refresh If true, fetches metadata from all providers. If false, uses cached metadata.
-   * @returns Token metadata and tags for the given mints. Excluded mints are not returned.
+   * @returns TokenResults containing metadata, tags, and flag indicating presence in this repo
    */
   async fetchMany(
     fetcher: TokenFetcher,
@@ -156,14 +156,12 @@ export class TokenRepository {
   }
 
   /**
-   * Fetches all token metadata and tags for all mints with the given tag.
-   * If a mint is excluded, it is not returned.
-   * If a mint is not in the repository, it is not returned.
+   * Fetches all tokens that have been tagged by a specific string in this repository.
+   *
    * @param fetcher TokenFetcher to use
    * @param tag Tag to get
    * @param refresh If true, fetches metadata from all providers. If false, uses cached metadata.
-   * @returns Token metadata and tags for all mints with the given tag. Excluded mints are not
-   * returned.
+   * @returns TokenResults containing metadata, tags, and flag indicating presence in this repo
    */
   async fetchByTag(fetcher: TokenFetcher, tag: string, refresh = false): Promise<TokenResult[]> {
     const mintSet = this.tagMap.get(tag);

--- a/packages/token-sdk/src/repository.ts
+++ b/packages/token-sdk/src/repository.ts
@@ -19,7 +19,8 @@ type MintEntry = {
 };
 
 /**
- * Manages a local database of tokens mints and provides a way to fetch metadata for them.
+ * Manages a local database of tokens mints and provides a way to attach additional metadata for
+ * tokens by augmenting the results from a TokenFetcher.
  *
  * Tags - Enables adding tags to mints that can be used for labeling and filtering. Tags can be set
  * for mints without adding the mints to the repository.

--- a/packages/token-sdk/src/repository.ts
+++ b/packages/token-sdk/src/repository.ts
@@ -179,11 +179,11 @@ export class TokenRepository {
    */
   has(mint: Address, tag?: string): boolean {
     const mintString = mint.toString();
-    if (tag === undefined) {
-      return this.mintMap.has(mintString);
-    }
     const entry = this.mintMap.get(mintString);
-    return entry?.tags.has(tag) ?? false;
+    if (!entry || !entry.exists) {
+      return false;
+    }
+    return tag !== undefined ? entry.tags.has(tag) : true;
   }
 
   /**

--- a/packages/token-sdk/src/repository.ts
+++ b/packages/token-sdk/src/repository.ts
@@ -27,7 +27,7 @@ type MintEntry = {
  *
  * Overrides - Enables overriding metadata for mints. Overrides are applied to fetched tokens.
  *
- * Fetching- Provides methods for fetching token metadata that also includes tags and a flag that
+ * Fetching - Provides methods for fetching token metadata that also includes tags and a flag that
  * indicates whether the token was added to this repository.
  */
 export class TokenRepository {

--- a/packages/token-sdk/src/repository.ts
+++ b/packages/token-sdk/src/repository.ts
@@ -212,11 +212,10 @@ export class TokenRepository {
         this.mintMap.set(mintString, { exists: addToRepo, tags: new Set() });
       }
       const entry = this.mintMap.get(mintString)!;
-      if (addToRepo) {
-        entry.exists = true;
-      }
       tags.forEach((tag) => entry.tags.add(tag));
-      this.mintMap.set(mintString, entry);
+      if (addToRepo && !entry.exists) {
+        this.mintMap.set(mintString, { ...entry, exists: true });
+      }
     });
 
     tags.forEach((tag) => {

--- a/packages/token-sdk/tests/repository.test.ts
+++ b/packages/token-sdk/tests/repository.test.ts
@@ -36,12 +36,14 @@ describe("token-repository", () => {
     expect(token1?.mint).toEqual(mint1);
     expect(token1?.symbol).toEqual("P1");
     expect(token1?.tags).toEqual(["whitelisted"]);
+    expect(token1?.exists).toBeTruthy();
 
     const token2 = await repo.fetch(fetcher, mint2);
     expect(token2).toBeDefined();
     expect(token2?.mint).toEqual(mint2);
     expect(token2?.symbol).toEqual("P2");
     expect(token2?.tags).toEqual([]);
+    expect(token2?.exists).toBeTruthy();
   });
 
   it("addMints ok", async () => {
@@ -54,6 +56,7 @@ describe("token-repository", () => {
       expect(tokens[i].mint).toEqual(mint);
       expect(tokens[i].symbol).toEqual(`P${i + 1}`);
       expect(tokens[i].tags).toEqual(["whitelisted"]);
+      expect(tokens[i].exists).toBeTruthy();
     });
   });
 
@@ -72,6 +75,7 @@ describe("token-repository", () => {
       expect(tokens[i].mint).toEqual(mint);
       expect(tokens[i].symbol).toEqual(`P${i + 1}`);
       expect(tokens[i].tags).toEqual(["whitelisted"]);
+      expect(tokens[i].exists).toBeTruthy();
     });
   });
 
@@ -86,31 +90,79 @@ describe("token-repository", () => {
     expect(tokens[0].mint).toEqual(mint1);
     expect(tokens[0].symbol).toEqual("P1");
     expect(tokens[0].tags).toEqual(["tag1", "tag2", "tag3"]);
+    expect(tokens[0].exists).toBeTruthy();
   });
 
-  it("get ok", async () => {
+  it("tagMints does not add to repository", async () => {
+    const repo = new TokenRepository().tagMints([mint1, mint2], ["tag2"]);
+    let tokens = await repo.fetchAll(fetcher);
+    expect(tokens.length).toEqual(0);
+  });
+
+  it("tagMints adds to existing mint", async () => {
+    const repo = new TokenRepository().addMint(mint1, ["tag1"]).tagMints([mint1], ["tag2"]);
+    let tokens = await repo.fetchAll(fetcher);
+    expect(tokens.length).toEqual(1);
+    expect(tokens[0].mint).toEqual(mint1);
+    expect(tokens[0].tags).toEqual(["tag1", "tag2"]);
+    expect(tokens[0].exists).toBeTruthy();
+  });
+
+  it("mints added after tagMints still have tag", async () => {
+    const repo = new TokenRepository().tagMints([mint1], ["tag1"]);
+    let tokens = await repo.fetchAll(fetcher);
+    expect(tokens.length).toEqual(0);
+
+    tokens = await repo.fetchMany(fetcher, [mint1]);
+    expect(tokens.length).toEqual(1);
+    expect(tokens[0].mint).toEqual(mint1);
+    expect(tokens[0].tags).toEqual(["tag1"]);
+    expect(tokens[0].exists).toBeFalsy();
+
+    repo.addMint(mint1);
+    tokens = await repo.fetchAll(fetcher);
+    expect(tokens.length).toEqual(1);
+    expect(tokens[0].mint).toEqual(mint1);
+    expect(tokens[0].tags).toEqual(["tag1"]);
+    expect(tokens[0].exists).toBeTruthy();
+  });
+
+  it("fetch ok", async () => {
     const repo = new TokenRepository().addMint(mint1, ["tag1"]);
-    const token = await repo.fetch(fetcher, mint1);
-    expect(token).toBeDefined();
-    expect(token?.mint).toEqual(mint1);
-    expect(token?.symbol).toEqual("P1");
-    expect(token?.tags).toEqual(["tag1"]);
+    const token1 = await repo.fetch(fetcher, mint1);
+    expect(token1).toBeDefined();
+    expect(token1?.mint).toEqual(mint1);
+    expect(token1?.symbol).toEqual("P1");
+    expect(token1?.tags).toEqual(["tag1"]);
+    expect(token1?.exists).toBeTruthy();
+
+    const token2 = await repo.fetch(fetcher, mint2);
+    expect(token2).toBeDefined();
+    expect(token2?.mint).toEqual(mint2);
+    expect(token2?.symbol).toEqual("P2");
+    expect(token2?.tags).toEqual([]);
+    expect(token2?.exists).toBeFalsy();
   });
 
   it("fetchMany ok", async () => {
-    const mints = [mint1, mint2, mint3];
-    const repo = new TokenRepository().addMints(mints, ["tag1"]);
-    const tokens = await repo.fetchMany(fetcher, mints);
-    expect(tokens.length).toEqual(3);
-    mints.forEach((mint, i) => {
-      expect(tokens[i]).toBeDefined();
-      expect(tokens[i].mint).toEqual(mint);
-      expect(tokens[i].symbol).toEqual(`P${i + 1}`);
-      expect(tokens[i].tags).toEqual(["tag1"]);
-    });
+    const repo = new TokenRepository().addMints([mint1], ["tag1"]);
+    const tokens = await repo.fetchMany(fetcher, [mint1, mint2]);
+    expect(tokens.length).toEqual(2);
+
+    expect(tokens[0]).toBeDefined();
+    expect(tokens[0]?.mint).toEqual(mint1);
+    expect(tokens[0]?.symbol).toEqual("P1");
+    expect(tokens[0]?.tags).toEqual(["tag1"]);
+    expect(tokens[0]?.exists).toBeTruthy();
+
+    expect(tokens[1]).toBeDefined();
+    expect(tokens[1]?.mint).toEqual(mint2);
+    expect(tokens[1]?.symbol).toEqual("P2");
+    expect(tokens[1]?.tags).toEqual([]);
+    expect(tokens[1]?.exists).toBeFalsy();
   });
 
-  it("getByTag ok", async () => {
+  it("fetchByTag ok", async () => {
     const mints = [mint1, mint2, mint3];
     const repo = new TokenRepository()
       .addMints(mints, ["whitelisted"])
@@ -122,6 +174,7 @@ describe("token-repository", () => {
       expect(token.mint).toEqual(mints[i]);
       expect(token.symbol).toEqual(`P${i + 1}`);
       expect(token.tags.includes("whitelisted")).toBeTruthy();
+      expect(token.exists).toBeTruthy();
     });
 
     const coingecko = await repo.fetchByTag(fetcher, "coingecko");
@@ -133,7 +186,7 @@ describe("token-repository", () => {
     expect(coingecko[0].tags[1]).toEqual("coingecko");
   });
 
-  it("get refresh refetches token metadata", async () => {
+  it("fetch refresh token metadata", async () => {
     const p1 = new FileSystemProvider(new Map([[mint1, { name: "P1 Token", symbol: "P1" }]]));
     fetcher = new TokenFetcher(ctx.connection).addProvider(p1);
 
@@ -143,6 +196,7 @@ describe("token-repository", () => {
     expect(token?.name).toEqual("P1 Token");
     expect(token?.symbol).toEqual("P1");
     expect(token?.image).toBeUndefined();
+    expect(token?.exists).toBeTruthy();
 
     const p2 = new FileSystemProvider(
       new Map([[mint1, { name: "P1 Token", symbol: "P1", image: "https://new_image.com" }]])
@@ -153,33 +207,21 @@ describe("token-repository", () => {
     expect(token?.name).toEqual("P1 Token");
     expect(token?.symbol).toEqual("P1");
     expect(token?.image).toEqual("https://new_image.com");
+    expect(token?.exists).toBeTruthy();
   });
 
-  it("excludeMints omitted from gets", async () => {
+  it("missing mints included in fetches but marked not exist", async () => {
     const mints = [mint1, mint2, mint3];
-    const repo = new TokenRepository()
-      .addMints(mints, ["whitelisted"])
-      .excludeMints([mint1])
-      .addMint(mint1);
-    let tokens = await repo.fetchAll(fetcher);
-    expect(tokens.length).toEqual(2);
-    expect(tokens[0].mint).toEqual(mint2);
-    expect(tokens[1].mint).toEqual(mint3);
-
-    repo.excludeMintlist({ name: "Test Mintlist", version: "0.0.1", mints: [mint2] });
-    tokens = await repo.fetchAll(fetcher);
-    expect(tokens.length).toEqual(1);
-    expect(tokens[0].mint).toEqual(mint3);
-  });
-
-  it("missing mints excluded from gets", async () => {
-    const missingMint = Keypair.generate().publicKey.toString();
-    const mints = [mint1, mint2, mint3];
-    const repo = new TokenRepository().addMints(mints, ["tag1"]);
-    const tokens = await repo.fetchMany(fetcher, [missingMint]);
-    expect(tokens.length).toEqual(0);
-    const token = await repo.fetch(fetcher, missingMint);
-    expect(token).toBeNull();
+    const repo = new TokenRepository();
+    const tokens = await repo.fetchMany(fetcher, mints);
+    expect(tokens.length).toEqual(3);
+    tokens.forEach((token) => {
+      expect(token).toBeDefined();
+      expect(token.exists).toBeFalsy();
+    });
+    const token = await repo.fetch(fetcher, mint1);
+    expect(token).toBeDefined();
+    expect(token?.exists).toBeFalsy();
   });
 
   it("overrides ok", async () => {
@@ -194,9 +236,15 @@ describe("token-repository", () => {
     expect(token1?.name).toEqual("Override P1");
     expect(token1?.symbol).toEqual("P1");
     expect(token1?.tags).toEqual(["tag1"]);
+    expect(token1?.exists).toBeTruthy();
 
     const token2 = await repo.fetch(fetcher, mint2);
-    expect(token2).toBeNull();
+    expect(token2).toBeDefined();
+    expect(token2?.mint).toEqual(mint2);
+    expect(token2?.name).toEqual("Override P2");
+    expect(token2?.symbol).toEqual("P2-override");
+    expect(token2?.tags).toEqual([]);
+    expect(token2?.exists).toBeFalsy();
   });
 
   it("has", async () => {

--- a/packages/token-sdk/tests/repository.test.ts
+++ b/packages/token-sdk/tests/repository.test.ts
@@ -257,5 +257,8 @@ describe("token-repository", () => {
     expect(repo.has(mint1, "whitelisted")).toBeFalsy();
     expect(repo.has(mint2)).toBeFalsy();
     expect(repo.has(mint2, "tag1")).toBeFalsy();
+
+    repo.tagMint(mint2, ["whitelisted"]);
+    expect(repo.has(mint2)).toBeFalsy();
   });
 });


### PR DESCRIPTION
https://app.asana.com/0/1204730191677489/1205117637172628/f

- Fetch methods return an additional flag indicating whether the token exists in the repository instance. This augments the TokenFetcher fetch methods with results derived from the context of the repository.
- Removed exclude functionality. Since fetch results have additional metadata that callers use for filtering, exclusion is now the responsibility of the caller to manage with their own tags - e.g. add "blocked" tag and filter out those results.
- Added ability to tags to mints without adding them to the repository.