### PR TITLE
Update TransactionProcessor to support v0 tx

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/transactions-processor.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-processor.ts
@@ -147,7 +147,6 @@ function rewriteTransaction(txRequest: SendTxRequest, feePayer: PublicKey, block
     }
     return tx;
   } else {
-    console.log(`Rewriting transaction - ${JSON.stringify(txRequest.transaction)}`)
     let tx: Transaction = txRequest.transaction;
     let signers = txRequest.signers ?? [];
 

--- a/packages/common-sdk/src/web3/transactions/transactions-processor.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-processor.ts
@@ -1,4 +1,10 @@
-import { Commitment, Connection, PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
+import {
+  Commitment,
+  Connection,
+  PublicKey,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { Wallet } from "../wallet";
 import { isVersionedTransaction } from "./transactions-builder";
 import { SendTxRequest } from "./types";
@@ -11,7 +17,7 @@ export class TransactionProcessor {
     readonly connection: Connection,
     readonly wallet: Wallet,
     readonly commitment: Commitment = "confirmed"
-  ) { }
+  ) {}
 
   public async signTransaction(txRequest: SendTxRequest): Promise<{
     transaction: Transaction | VersionedTransaction;

--- a/packages/common-sdk/src/web3/transactions/transactions-processor.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-processor.ts
@@ -1,5 +1,6 @@
-import { Commitment, Connection, PublicKey, Signer, Transaction } from "@solana/web3.js";
+import { Commitment, Connection, PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { Wallet } from "../wallet";
+import { isVersionedTransaction } from "./transactions-builder";
 import { SendTxRequest } from "./types";
 
 /**
@@ -10,10 +11,10 @@ export class TransactionProcessor {
     readonly connection: Connection,
     readonly wallet: Wallet,
     readonly commitment: Commitment = "confirmed"
-  ) {}
+  ) { }
 
   public async signTransaction(txRequest: SendTxRequest): Promise<{
-    transaction: Transaction;
+    transaction: Transaction | VersionedTransaction;
     lastValidBlockHeight: number;
     blockhash: string;
   }> {
@@ -24,7 +25,7 @@ export class TransactionProcessor {
   }
 
   public async signTransactions(txRequests: SendTxRequest[]): Promise<{
-    transactions: Transaction[];
+    transactions: (Transaction | VersionedTransaction)[];
     lastValidBlockHeight: number;
     blockhash: string;
   }> {
@@ -44,7 +45,7 @@ export class TransactionProcessor {
   }
 
   public async sendTransaction(
-    transaction: Transaction,
+    transaction: Transaction | VersionedTransaction,
     lastValidBlockHeight: number,
     blockhash: string
   ): Promise<string> {
@@ -59,12 +60,12 @@ export class TransactionProcessor {
   }
 
   public constructSendTransactions(
-    transactions: Transaction[],
+    transactions: (Transaction | VersionedTransaction)[],
     lastValidBlockHeight: number,
     blockhash: string,
     parallel: boolean = true
   ): () => Promise<PromiseSettledResult<string>[]> {
-    const executeTx = async (tx: Transaction) => {
+    const executeTx = async (tx: Transaction | VersionedTransaction) => {
       const rawTxs = tx.serialize();
       return this.connection.sendRawTransaction(rawTxs, {
         preflightCommitment: this.commitment,
@@ -108,7 +109,7 @@ export class TransactionProcessor {
   }
 
   public async signAndConstructTransaction(txRequest: SendTxRequest): Promise<{
-    signedTx: Transaction;
+    signedTx: Transaction | VersionedTransaction;
     execute: () => Promise<string>;
   }> {
     const { transaction, lastValidBlockHeight, blockhash } = await this.signTransaction(txRequest);
@@ -122,7 +123,7 @@ export class TransactionProcessor {
     txRequests: SendTxRequest[],
     parallel: boolean = true
   ): Promise<{
-    signedTxs: Transaction[];
+    signedTxs: (Transaction | VersionedTransaction)[];
     execute: () => Promise<PromiseSettledResult<string>[]>;
   }> {
     const { transactions, lastValidBlockHeight, blockhash } = await this.signTransactions(
@@ -139,10 +140,23 @@ export class TransactionProcessor {
 }
 
 function rewriteTransaction(txRequest: SendTxRequest, feePayer: PublicKey, blockhash: string) {
-  const signers = txRequest.signers ?? [];
-  const tx = txRequest.transaction;
-  tx.feePayer = feePayer;
-  tx.recentBlockhash = blockhash;
-  signers.filter((s): s is Signer => s !== undefined).forEach((keypair) => tx.partialSign(keypair));
-  return tx;
+  if (isVersionedTransaction(txRequest.transaction)) {
+    let tx: VersionedTransaction = txRequest.transaction;
+    if (txRequest.signers) {
+      tx.sign(txRequest.signers ?? []);
+    }
+    return tx;
+  } else {
+    console.log(`Rewriting transaction - ${JSON.stringify(txRequest.transaction)}`)
+    let tx: Transaction = txRequest.transaction;
+    let signers = txRequest.signers ?? [];
+
+    tx.feePayer = feePayer;
+    tx.recentBlockhash = blockhash;
+
+    signers.forEach((kp) => {
+      tx.partialSign(kp);
+    });
+    return tx;
+  }
 }

--- a/packages/common-sdk/src/web3/transactions/types.ts
+++ b/packages/common-sdk/src/web3/transactions/types.ts
@@ -38,6 +38,6 @@ export type TransactionPayload = {
  * @deprecated
  */
 export type SendTxRequest = {
-  transaction: Transaction;
-  signers?: Array<Signer | undefined>;
+  transaction: Transaction | VersionedTransaction;
+  signers?: Signer[];
 };


### PR DESCRIPTION
## Verification
- Verified using use-cases on multi-tx builder calls on Orca2 (ex. harvestAll)

## Note
- Although TP has been deprecated, the alternative is not ready for release. So updating it is the best short term solution
