### PR TITLE
Bumping token-sdk version

### DIFF
--- a/packages/mintlist-cli/README.md
+++ b/packages/mintlist-cli/README.md
@@ -9,5 +9,5 @@ The goal is to separate dev dependencies from the `token-sdk` package and the `o
 
 - `add-mint`: Adds a mint to a mintlist. No-op if duplicate. Sorts mints.
 - `remove-mint`: Removes a mint from a mintlist. No-op if duplicate. Sorts mints.
-- `gen-tokenlist`: Generates a tokenlist containing token metadata from a mintlist. TODO: Make `TokenFetcher` providers configurable.
-- `gen-index`: Generates an `index.ts` file that exports all mintlist and tokenlist JSON files.
+- `lint`: Lints mintlists and overrides files by detecting formatting issues and alphabetical sorting.
+- `format`: Formats files by fixing any detected lint errors.

--- a/packages/mintlist-cli/package.json
+++ b/packages/mintlist-cli/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "dependencies": {
-    "@orca-so/token-sdk": "0.1.6-beta.7",
+    "@orca-so/token-sdk": "0.1.6",
     "@solana/web3.js": "^1.73.3",
     "commander": "^10.0.0",
     "mz": "^2.7.0"

--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.1.6-beta.7",
+  "version": "0.1.6",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",


### PR DESCRIPTION
Bumping `@orca-so/token-sdk` version to latest (removing beta tag)
https://www.npmjs.com/package/@orca-so/token-sdk/v/0.1.6

Updating `mintlist-cli` readme.