### PR TITLE
Fix: case sensitive comparing for SolanaFM response

### DIFF
--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/token-sdk/src/metadata/client/solanafm-client.ts
+++ b/packages/token-sdk/src/metadata/client/solanafm-client.ts
@@ -21,7 +21,10 @@ export class SolanaFmHttpClient implements SolanaFmClient {
     invariant(response.ok, `Unexpected status code fetching ${url}: ${response.status}`);
     const json = await response.json();
     invariant(isGetTokenResponse(json), "Unexpected SolanaFM getToken response type");
-    invariant(json.status === "success", "Unexpected SolanaFM getToken response status");
+    invariant(
+      json.status.localeCompare("success", undefined, { sensitivity: "base" }) === 0,
+      "Unexpected SolanaFM getToken response status"
+    );
     return json.result;
   }
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202413563699470/1205765967219680/f

SDK rejected SolanaFM response due to case sensitive comparison ``"success" === "Success"``.