### PR TITLE
Remove dependency on metaplex-js sdk

### DIFF
--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -8,9 +8,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@metaplex-foundation/mpl-token-metadata": "^3.1.0",
-    "@metaplex-foundation/umi": "^0.8.9",
-    "@metaplex-foundation/umi-bundle-defaults": "^0.8.9",
     "@orca-so/common-sdk": "^0.3.1",
     "@solana/spl-token": "0.3.8",
     "@solana/web3.js": "^1.75.0",

--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",
@@ -8,7 +8,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@metaplex-foundation/js": "^0.19.4",
+    "@metaplex-foundation/mpl-token-metadata": "^3.1.0",
+    "@metaplex-foundation/umi": "^0.8.9",
+    "@metaplex-foundation/umi-bundle-defaults": "^0.8.9",
     "@orca-so/common-sdk": "^0.3.1",
     "@solana/spl-token": "0.3.8",
     "@solana/web3.js": "^1.75.0",

--- a/packages/token-sdk/src/metadata/client/index.ts
+++ b/packages/token-sdk/src/metadata/client/index.ts
@@ -1,2 +1,3 @@
 export * from "./coingecko-client";
+export * from "./metaplex-client";
 export * from "./solanafm-client";

--- a/packages/token-sdk/src/metadata/client/metaplex-client.ts
+++ b/packages/token-sdk/src/metadata/client/metaplex-client.ts
@@ -1,0 +1,215 @@
+import { PublicKey } from "@solana/web3.js";
+import fetch from "isomorphic-unfetch";
+import invariant from "tiny-invariant";
+
+const METADATA_PROGRAM_ID = new PublicKey("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+
+interface Creator {
+  address: PublicKey;
+  verified: boolean;
+  share: number;
+}
+
+interface Collection {
+  verified: boolean;
+  key: PublicKey;
+}
+
+interface Uses {
+  useMethod: number;
+  remaining: BigInt;
+  total: BigInt;
+}
+
+interface OnChainMetadataPrefix {
+  key: number;
+  updateAuthority: PublicKey;
+  mint: PublicKey;
+  name: string;
+  symbol: string;
+  uri: string;
+  sellerFeeBasisPoints: number;
+}
+
+interface OnChainMetadataCreators {
+  creators: Creator[];
+}
+
+interface OnChainMetadataSuffix {
+  primarySaleHappened: boolean;
+  isMutable: boolean;
+  editionNonce: number | null;
+  tokenStandard: number | null;
+  collection: Collection | null;
+  uses: Uses | null;
+}
+
+export type OnChainMetadata = OnChainMetadataPrefix & OnChainMetadataCreators & OnChainMetadataSuffix
+
+export interface OffChainMetadata {
+  name?: string;
+  symbol?: string;
+  description?: string;
+  image?: string;
+}
+
+export interface MetaplexClient {
+  getMetadataAddress(mint: PublicKey): PublicKey;
+  parseOnChainMetadata(mint: PublicKey, buffer: Buffer | Uint8Array): OnChainMetadata | null;
+  getOffChainMetadata(metadata: OnChainMetadata): Promise<OffChainMetadata | null>;
+}
+
+export class MetaplexHttpClient implements MetaplexClient {
+
+  getMetadataAddress(mint: PublicKey): PublicKey {
+    const seeds = [Buffer.from("metadata"), METADATA_PROGRAM_ID.toBuffer(), mint.toBuffer()];
+    return PublicKey.findProgramAddressSync(seeds, METADATA_PROGRAM_ID)[0];
+  }
+
+  parseOnChainMetadata(mint: PublicKey, data: Uint8Array | Buffer): OnChainMetadata | null {
+    try {
+      const buffer = Buffer.from(data);
+      const [prefix, creatorsOffset] = parseOnChainMetadataPrefix(buffer, 0);
+      const [creators, suffixOffset] = parseOnChainMetadataCreators(buffer, creatorsOffset);
+      const [suffix] = parseOnChainMetadataSuffix(buffer, suffixOffset);
+      return { ...prefix, ...creators, ...suffix };
+    } catch {
+      console.error(`Failed to parse onchain metadata for ${mint}`)
+      return null;
+    }
+  }
+
+  async getOffChainMetadata(metadata: OnChainMetadata): Promise<OffChainMetadata | null> {
+    try {
+      if (metadata.uri === "") {
+        return null;
+      }
+      const response = await fetch(metadata.uri);
+      if (response.status === 404) {
+        return null;
+      }
+      invariant(response.ok, `Unexpected status code fetching ${metadata.uri}: ${response.status}`);
+      const json = await response.json();
+      invariant(isMetadataResponse(json), "Unexpected offchain metadata response type");
+      return json;
+    } catch {
+      console.error(`Failed to fetch offchain metadata for ${metadata.mint}`)
+      return null;
+    }
+  }
+}
+
+function readString(buffer: Buffer, offset: number): string {
+  const readLength = buffer.readUInt32LE(offset);
+  const bytes = buffer.subarray(offset + 4, offset + 4 + readLength);
+  const nullIndex = bytes.indexOf(0);
+  return new TextDecoder().decode(bytes.subarray(0, nullIndex));
+}
+
+function parseOnChainMetadataPrefix(buffer: Buffer, offset: number): [OnChainMetadataPrefix, number] {
+  const key = buffer.readUInt8(offset);
+  offset += 1;
+  const updateAuthority = new PublicKey(buffer.subarray(offset, offset + 32));
+  offset += 32;
+  const mint = new PublicKey(buffer.subarray(offset, offset + 32));
+  offset += 32;
+  const name = readString(buffer, offset);
+  offset += 36;
+  const symbol = readString(buffer, offset);
+  offset += 14;
+  const uri = readString(buffer, offset);
+  offset += 204;
+  const sellerFeeBasisPoints = buffer.readUInt16LE(offset);
+  offset += 2;
+  return [
+    { key, updateAuthority, mint, name, symbol, uri, sellerFeeBasisPoints },
+    offset
+  ];
+}
+
+function parseOnChainMetadataCreators(buffer: Buffer, offset: number): [OnChainMetadataCreators, number] {
+  const creatorsPresent = !!buffer.readUInt8(offset);
+  offset += 1;
+  if (!creatorsPresent) {
+    return [{ creators: [] }, offset];
+  }
+  const creatorCount = buffer.readUInt16LE(offset);
+  offset += 4;
+  let creators: Creator[] = [];
+  for (let i = 0; i < creatorCount; i++) {
+    const address = new PublicKey(buffer.subarray(offset, offset + 32));
+    offset += 32;
+    const verified = !!buffer.readUInt8(offset);
+    offset += 1;
+    const share = buffer.readUInt8(offset);
+    offset += 1;
+    creators.push({ address, verified, share });
+  }
+  return [{ creators }, offset] ;
+}
+
+function parseOnChainMetadataSuffix(buffer: Buffer, offset: number): [OnChainMetadataSuffix, number] {
+  const primarySaleHappened = !!buffer.readUInt8(offset);
+  offset += 1;
+  const isMutable = !!buffer.readUInt8(offset);
+  offset += 1;
+  const editionNoncePresent = !!buffer.readUInt8(offset);
+  offset += 1;
+  let editionNonce: number | null = null;
+  if (editionNoncePresent) {
+    editionNonce = editionNoncePresent ? buffer.readUInt8(offset) : null;
+    offset += 1;
+  }
+  const tokenStandardPresent = !!buffer.readUInt8(offset);
+  offset += 1;
+  let tokenStandard: number | null = null;
+  if (tokenStandardPresent) {
+    tokenStandard = tokenStandardPresent ? buffer.readUInt8(offset) : null;
+    offset += 1;
+  }
+  const collectionPresent = !!buffer.readUInt8(offset);
+  offset += 1;
+  let collection: Collection | null = null;
+  if (collectionPresent) {
+    const collectionVerified = !!buffer.readUInt8(offset);
+    offset += 1;
+    const collectionKey =  new PublicKey(buffer.subarray(offset, offset + 32));
+    offset += 32;
+    collection = collectionPresent ? { verified: collectionVerified, key: collectionKey } : null;
+  }
+  const usesPresent = !!buffer.readUInt8(offset);
+  offset += 1;
+  let uses: Uses | null = null;
+  if (usesPresent) {
+    const useMethod = buffer.readUInt8(offset);
+    offset += 1;
+    const remaining = buffer.readBigUInt64LE(offset);
+    offset += 8;
+    const total = buffer.readBigUInt64LE(offset);
+    offset += 8;
+    uses = usesPresent ? { useMethod, remaining, total } : null;
+  }
+  return [
+    { primarySaleHappened, isMutable, editionNonce, tokenStandard, collection, uses },
+    offset
+  ];
+}
+
+function isMetadataResponse(value: any): value is OffChainMetadata {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (value.name && typeof value.name !== "string") {
+    return false;
+  }
+  if (value.image && typeof value.image !== "string") {
+    return false;
+  }
+  if (value.description && typeof value.description !== "string") {
+    return false;
+  }
+  if (value.symbol && typeof value.symbol !== "string") {
+    return false;
+  }
+  return true;
+}

--- a/packages/token-sdk/src/metadata/client/solanafm-client.ts
+++ b/packages/token-sdk/src/metadata/client/solanafm-client.ts
@@ -5,12 +5,12 @@ const SOLANA_FM_API_URL = "https://api.solana.fm/v0";
 const TOKENS_PATH = "tokens";
 
 export interface SolanaFmClient {
-  getToken(tokenHash: string): Promise<TokenResult>;
-  getTokens(tokenHashes: string[]): Promise<TokenResult[]>;
+  getToken(tokenHash: string): Promise<TokenResponseResult>;
+  getTokens(tokenHashes: string[]): Promise<TokenResponseResult[]>;
 }
 
 export class SolanaFmHttpClient implements SolanaFmClient {
-  async getToken(tokenHash: string): Promise<TokenResult> {
+  async getToken(tokenHash: string): Promise<TokenResponseResult> {
     const url = `${SOLANA_FM_API_URL}/${TOKENS_PATH}/${tokenHash}`;
     let response;
     try {
@@ -28,7 +28,7 @@ export class SolanaFmHttpClient implements SolanaFmClient {
     return json.result;
   }
 
-  async getTokens(tokenHashes: string[]): Promise<TokenResult[]> {
+  async getTokens(tokenHashes: string[]): Promise<TokenResponseResult[]> {
     const url = `${SOLANA_FM_API_URL}/${TOKENS_PATH}`;
     let response;
     try {
@@ -54,16 +54,16 @@ export class SolanaFmHttpClient implements SolanaFmClient {
 export interface GetTokenResponse {
   status: string;
   message: string;
-  result: TokenResult;
+  result: TokenResponseResult;
 }
 
 export interface GetTokensResponse {
   status: string;
   message: string;
-  result: TokenResult[];
+  result: TokenResponseResult[];
 }
 
-export interface TokenResult {
+export interface TokenResponseResult {
   tokenHash: string;
   data: {
     mint: string;

--- a/packages/token-sdk/src/metadata/index.ts
+++ b/packages/token-sdk/src/metadata/index.ts
@@ -1,3 +1,4 @@
+export * from "./client";
 export * from "./coingecko-provider";
 export * from "./filesystem-provider";
 export * from "./metadata-util";

--- a/packages/token-sdk/src/metadata/metaplex-provider.ts
+++ b/packages/token-sdk/src/metadata/metaplex-provider.ts
@@ -44,7 +44,7 @@ export class MetaplexProvider implements MetadataProvider {
       return null;
     }
     let image: string | undefined;
-    if (this.opts.loadImage) {
+    if (this.opts.loadImage ?? true) {
       const json = await this.client.getOffChainMetadata(meta);
       if (json) {
         image = json.image;
@@ -77,7 +77,7 @@ export class MetaplexProvider implements MetadataProvider {
     const metas = datas.map((data, index) => data ? this.client.parseOnChainMetadata(pdas[index], data) : null);
     let jsons = Array<OffChainMetadata | null>(metas.length);
     const jsonHandlers = Array<() => Promise<void>>();
-    if (this.opts.loadImage) {
+    if (this.opts.loadImage ?? true) {
       for (let i = 0; i < metas.length; i += 1) {
         const meta = metas[i];
         if (!meta) {

--- a/packages/token-sdk/src/metadata/metaplex-provider.ts
+++ b/packages/token-sdk/src/metadata/metaplex-provider.ts
@@ -1,18 +1,11 @@
-import {
-  isMetadata,
-  Metaplex,
-  Nft,
-  Sft,
-  Metadata as MetaplexMetadata,
-  toMetaplexFile,
-  Amount,
-  MetaplexFile,
-} from "@metaplex-foundation/js";
+
 import { Connection } from "@solana/web3.js";
 import { MetadataProvider, Metadata } from "./types";
 import { Address, AddressUtil } from "@orca-so/common-sdk";
-import fetch from "isomorphic-unfetch";
 import PQueue from "p-queue";
+import { Context, publicKey } from "@metaplex-foundation/umi";
+import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
+import { fetchJsonMetadata, fetchMetadata, fetchAllMetadata, findMetadataPda, Metadata as MetaplexMetadata, JsonMetadata } from "@metaplex-foundation/mpl-token-metadata";
 
 const DEFAULT_CONCURRENCY = 5;
 const DEFAULT_INTERVAL_MS = 1000;
@@ -29,93 +22,51 @@ interface Opts {
 }
 
 export class MetaplexProvider implements MetadataProvider {
-  private readonly metaplex: Metaplex;
+  private readonly ctx: Context;
   private readonly queue: PQueue;
   private readonly opts: Opts;
 
   constructor(connection: Connection, opts: Opts = {}) {
     const { concurrency = DEFAULT_CONCURRENCY, intervalMs = DEFAULT_INTERVAL_MS } = opts;
-    this.metaplex = createMetaplex(connection);
+    this.ctx = createUmi(connection.rpcEndpoint);
 
     this.queue = new PQueue({ concurrency, interval: intervalMs });
     this.opts = opts;
   }
 
   async find(address: Address): Promise<Readonly<Metadata> | null> {
-    let metadata;
     try {
-      metadata = await this.metaplex
-        .nfts()
-        .findByMint({ mintAddress: AddressUtil.toPubKey(address) });
+      const pda = findMetadataPda(this.ctx, { mint: publicKey(address)});
+      const meta = await fetchMetadata(this.ctx, pda);
+      let image: string | undefined;
+      if (this.opts.loadImage) {
+        const json = await fetchJsonMetadata(this.ctx, meta.uri);
+        image = json.image;
+      }
+      return { symbol: meta.symbol, name: meta.name, image };
     } catch (e) {
       return null;
     }
-    return transformMetadata(metadata);
   }
 
   async findMany(addresses: Address[]): Promise<ReadonlyMap<string, Metadata | null>> {
     const mints = AddressUtil.toPubKeys(addresses);
-    const results = await this.metaplex.nfts().findAllByMintList({ mints });
-    const loadImage = this.opts.loadImage ?? true;
-    const loaded = await Promise.all(
-      results.map((result) => {
-        if (!result) {
-          return null;
-        } else if (loadImage && isMetadata(result)) {
-          return this.queue.add(async () => this.metaplex.nfts().load({ metadata: result }));
-        } else {
-          return result;
-        }
-      })
-    );
+    const pdas = mints.map((mint) => findMetadataPda(this.ctx, { mint: publicKey(mint)}));
+    const metas = await fetchAllMetadata(this.ctx, pdas);
+    let jsons = Array<JsonMetadata | undefined>(metas.length);
+    if (this.opts.loadImage) {
+      jsons = await this.queue.addAll(
+        metas.map((meta) => async () => fetchJsonMetadata(this.ctx, meta.uri))
+      );
+    }
+
     return new Map(
-      loaded.map((metadata, index) => {
+      metas.map((meta, index) => {
         const mint = mints[index].toBase58();
-        const result = metadata ? transformMetadata(metadata) : null;
+        const json = jsons[index];
+        const result = { symbol: meta.symbol, name: meta.name, image: json?.image };
         return [mint, result];
       })
     );
   }
 }
-
-// https://docs.metaplex.com/programs/token-metadata/token-standard
-function transformMetadata(token: Sft | Nft | MetaplexMetadata): Metadata {
-  const metadata: Metadata = {
-    symbol: token.symbol,
-    name: token.name,
-  };
-  // Image is in offchain JSON file. Only populate if JSON file was loaded.
-  if (token.jsonLoaded && token.json) {
-    metadata.image = token.json.image;
-  }
-  return metadata;
-}
-
-// HACK: to avoid the following error
-// TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
-//
-// https://github.com/metaplex-foundation/js/issues/459 (closed but not fixed)
-//
-// Without this hack, the download of the Json file containing the Metadata will fail
-// and "image" metadata will not be retrieved. However, no error will occur.
-//
-// reference: https://github.com/metaplex-foundation/js/blob/4c2c4eafc2158ab6970073f3d49181228ed54260/packages/js/src/plugins/storageModule/StorageClient.ts#L72-L75
-function createMetaplex(connection: Connection): Metaplex {
-  const metaplex = Metaplex.make(connection);
-  metaplex.storage().setDriver(storageDriver);
-  return metaplex;
-}
-
-const storageDriver = {
-  download: async (uri: string, options: any) => {
-    const response = await fetch(uri, options);
-    const buffer = await response.arrayBuffer();
-    return toMetaplexFile(buffer, uri);
-  },
-  getUploadPrice: function (bytes: number): Promise<Amount> {
-    throw new Error("Function not implemented.");
-  },
-  upload: function (file: MetaplexFile): Promise<string> {
-    throw new Error("Function not implemented.");
-  },
-};

--- a/packages/token-sdk/src/metadata/metaplex-provider.ts
+++ b/packages/token-sdk/src/metadata/metaplex-provider.ts
@@ -1,11 +1,9 @@
 
-import { Connection } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import { MetadataProvider, Metadata } from "./types";
 import { Address, AddressUtil } from "@orca-so/common-sdk";
 import PQueue from "p-queue";
-import { Context, publicKey } from "@metaplex-foundation/umi";
-import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-import { fetchJsonMetadata, fetchMetadata, fetchAllMetadata, findMetadataPda, Metadata as MetaplexMetadata, JsonMetadata } from "@metaplex-foundation/mpl-token-metadata";
+import { MetaplexClient, MetaplexHttpClient, OffChainMetadata } from "./client";
 
 const DEFAULT_CONCURRENCY = 5;
 const DEFAULT_INTERVAL_MS = 1000;
@@ -22,51 +20,91 @@ interface Opts {
 }
 
 export class MetaplexProvider implements MetadataProvider {
-  private readonly ctx: Context;
+  private readonly connection: Connection;
+  private readonly client: MetaplexClient;
   private readonly queue: PQueue;
   private readonly opts: Opts;
 
   constructor(connection: Connection, opts: Opts = {}) {
     const { concurrency = DEFAULT_CONCURRENCY, intervalMs = DEFAULT_INTERVAL_MS } = opts;
-    this.ctx = createUmi(connection.rpcEndpoint);
-
+    this.connection = connection;
+    this.client = new MetaplexHttpClient();
     this.queue = new PQueue({ concurrency, interval: intervalMs });
     this.opts = opts;
   }
 
   async find(address: Address): Promise<Readonly<Metadata> | null> {
-    try {
-      const pda = findMetadataPda(this.ctx, { mint: publicKey(address)});
-      const meta = await fetchMetadata(this.ctx, pda);
-      let image: string | undefined;
-      if (this.opts.loadImage) {
-        const json = await fetchJsonMetadata(this.ctx, meta.uri);
-        image = json.image;
-      }
-      return { symbol: meta.symbol, name: meta.name, image };
-    } catch (e) {
+    const pda = this.client.getMetadataAddress(new PublicKey(address));
+    const info = await this.connection.getAccountInfo(pda);
+    if (!info) {
       return null;
     }
+    const meta = this.client.parseOnChainMetadata(pda, info.data);
+    if (!meta) {
+      return null;
+    }
+    let image: string | undefined;
+    if (this.opts.loadImage) {
+      const json = await this.client.getOffChainMetadata(meta);
+      if (json) {
+        image = json.image;
+      }
+    }
+    return { symbol: meta.symbol, name: meta.name, image };
   }
 
   async findMany(addresses: Address[]): Promise<ReadonlyMap<string, Metadata | null>> {
     const mints = AddressUtil.toPubKeys(addresses);
-    const pdas = mints.map((mint) => findMetadataPda(this.ctx, { mint: publicKey(mint)}));
-    const metas = await fetchAllMetadata(this.ctx, pdas);
-    let jsons = Array<JsonMetadata | undefined>(metas.length);
-    if (this.opts.loadImage) {
-      jsons = await this.queue.addAll(
-        metas.map((meta) => async () => fetchJsonMetadata(this.ctx, meta.uri))
-      );
+    const pdas = mints.map((mint) => this.client.getMetadataAddress(mint));
+
+    // chunk the requests into groups of 100 since this is the max number of accounts
+    // that can be fetched in a single request using `getMultipleAccountsInfo`
+    let datas = Array<Buffer | null>(pdas.length);
+    const dataHandlers = Array<() => Promise<void>>();
+    const chunkSize = 100;
+    for (let i = 0; i < pdas.length; i += chunkSize) {
+      const chunk = pdas.slice(i, i + chunkSize);
+      dataHandlers.push(async () => {
+        const chunkInfos = await this.connection.getMultipleAccountsInfo(chunk);
+        for (let j = 0; j < chunkInfos.length; j++) {
+          datas[i + j] = chunkInfos[j]?.data ?? null;
+        }
+      });
     }
 
-    return new Map(
-      metas.map((meta, index) => {
-        const mint = mints[index].toBase58();
-        const json = jsons[index];
-        const result = { symbol: meta.symbol, name: meta.name, image: json?.image };
-        return [mint, result];
-      })
-    );
+    await this.queue.addAll(dataHandlers);
+
+    const metas = datas.map((data, index) => data ? this.client.parseOnChainMetadata(pdas[index], data) : null);
+    let jsons = Array<OffChainMetadata | null>(metas.length);
+    const jsonHandlers = Array<() => Promise<void>>();
+    if (this.opts.loadImage) {
+      for (let i = 0; i < metas.length; i += 1) {
+        const meta = metas[i];
+        if (!meta) {
+          continue;
+        }
+        jsonHandlers.push(async () => {
+          const json = await this.client.getOffChainMetadata(meta);
+          jsons[i] = json;
+        });
+      }
+    }
+
+    await this.queue.addAll(jsonHandlers);
+
+    const map = new Map<string, Metadata | null>();
+
+    for (let i = 0; i < pdas.length; i += 1) {
+      const mint = mints[i];
+      const meta = metas[i];
+      const json = jsons[i];
+      if (!meta) {
+        continue;
+      }
+      const result = { symbol: meta.symbol, name: meta.name, image: json?.image };
+      map.set(mint.toString(), result);
+    }
+
+    return map;
   }
 }

--- a/packages/token-sdk/src/metadata/solanafm-provider.ts
+++ b/packages/token-sdk/src/metadata/solanafm-provider.ts
@@ -1,6 +1,6 @@
 import { Address, AddressUtil } from "@orca-so/common-sdk";
 import PQueue from "p-queue";
-import { SolanaFmClient, SolanaFmHttpClient, TokenResult } from "./client";
+import { SolanaFmClient, SolanaFmHttpClient, TokenResponseResult } from "./client";
 import { MetadataProvider, Metadata } from "./types";
 
 const DEFAULT_CONCURRENCY = 5;
@@ -34,7 +34,7 @@ export class SolanaFmProvider implements MetadataProvider {
 
   async findMany(addresses: Address[]): Promise<ReadonlyMap<string, Metadata | null>> {
     const mints = AddressUtil.toPubKeys(addresses).map((m) => m.toBase58());
-    const responses: Promise<TokenResult[]>[] = [];
+    const responses: Promise<TokenResponseResult[]>[] = [];
     const chunkSize = 50;
     for (let i = 0; i < mints.length; i += chunkSize) {
       const chunk = mints.slice(i, i + chunkSize);
@@ -51,7 +51,7 @@ export class SolanaFmProvider implements MetadataProvider {
   }
 }
 
-function convertToTokenMetadata(value: TokenResult): Metadata {
+function convertToTokenMetadata(value: TokenResponseResult): Metadata {
   return {
     symbol: value.data.symbol,
     name: value.data.tokenName,

--- a/packages/token-sdk/tests/onchain.test.ts
+++ b/packages/token-sdk/tests/onchain.test.ts
@@ -1,0 +1,112 @@
+import { PublicKey } from "@solana/web3.js";
+import { MetaplexHttpClient } from "../src/metadata/client";
+
+const sampleMetadata1 = Buffer.from("BFtPgBm85dopS9rNZwwfyKR/ckQ3Wtibj3XaT2e/MICsyEEWcJXwAK+lN+rJl013aKLNt+DXsGEWdx46Idsv6b4gAAAAT3JjYW5hdXRzICMyOTM0AAAAAAAAAAAAAAAAAAAAAAAKAAAAT1JDQU5BVVQAAMgAAABodHRwczovL2Fyd2VhdmUubmV0LzFmcHRCQnQwd0pJaUJCd1Q4SVJzSjgxSzRVOUpQS0JQcTlDOVBwbjU4Y2cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwBAQQAAAB/XDjW1aOvfsfwlZDQz8Z6g/dsaRpEmcw19IvYgc5l4QEAml6UEsJRfGHX3Z2h6YEIVDK2j9x+ddIy2ebdhCF5skcAAES/tpyc+5d2PmBqnv9xYsngE/am7+MEXf0mQx5uTGaSAADBvCrbgMWOJ2jE7lxd85ewIH0xwp4hKINk5+SJIxYBdABkAQEB/wABAZHCaV2VWTU4CrK3bD+z46tAhWUNhrm4EdHhRW63PQAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64");
+const sampleMetadata2 = Buffer.from("BOiqde3lG/8XvxD8vqpMr/LUtsZXBktLyzJ7KHzueYU3dN1qU/cb69+5ug0Zyl4e3c9wKAa2p56nQirpEtUG8aogAAAAU01CIEdlbjMgIzM5OTEAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAAAAAAAAAMgAAABodHRwczovL25mdHN0b3JhZ2UubGluay9pcGZzL2JhZnliZWlmbjV4dHZzdGI0dTVka2I2dXdwcDRybW8zcDVmdG5sNWR5ZGNwYWxmYTJybmN1eWltbW15LzM5OTAuanNvbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQBAQQAAAD06xKzXd7Ih163wYaNfUCkElt/43PRevP077LIc7TRuAEADQF1NmTDegYttMeeYNFYbH6cROyTNRJ0LdHRtp6txf8AAPo99i5mF81njuJb9ov1e7SDGyp5zUAAlCzUhTVFFCfBAFh10EH7UEZN79gGauZrIaJzBMrHu7AslrlSO+gQdW0nlwAMAQEB/gEEAQFuYXTE9cSHgIzncyjZA79aqs6npiPHSzvGFlxImICC4AAAAQABjwQ2Kt+32Y+KaVsg0zjcNGZY67+8ief3OL1UZE4JuSIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64");
+const sampleMetadata3 = Buffer.from("BFtPgBm85dopS9rNZwwfyKR/ckQ3Wtibj3XaT2e/MICskcJpXZVZNTgKsrdsP7Pjq0CFZQ2GubgR0eFFbrc9ABsgAAAAT3JjYW5hdXRzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAT1JDQU5BVVQAAMgAAABodHRwczovL2Fyd2VhdmUubmV0L3VfcDlWUTBxUWNRSl92ZVpMdndtdTBqZC0ydGRDNlVHam5wdmFtaGZucGMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAAABbT4AZvOXaKUvazWcMH8ikf3JEN1rYm4912k9nvzCArAFkAAEB/wEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64");
+const publicKey = new PublicKey("EUi6zrVQLqMtAZwQ8akyrJkGtBRWxPYK29SD1gGLtgNy")
+
+describe("onchain-metadata", () => {
+  const client = new MetaplexHttpClient();
+
+  it("get metadata address", () => {
+    const address = client.getMetadataAddress(publicKey);
+    expect(address.toString()).toEqual("J5S5ic4maffemW4NLkEuMU3YFcp2hBL5vzjbTdHCc765");
+  });
+
+  it("parse onchain metadata 1", () => {
+    const metadata = client.parseOnChainMetadata(publicKey, sampleMetadata1);
+    expect(metadata?.updateAuthority.toString()).toEqual("79SQqm8SUyLR21cXk5TEGCtkjWnN7NwBjUUY2aYUci8B");
+    expect(metadata?.mint.toString()).toEqual("EUi6zrVQLqMtAZwQ8akyrJkGtBRWxPYK29SD1gGLtgNy");
+    expect(metadata?.name).toEqual("Orcanauts #2934");
+    expect(metadata?.symbol).toEqual("ORCANAUT");
+    expect(metadata?.uri).toEqual("https://arweave.net/1fptBBt0wJIiBBwT8IRsJ81K4U9JPKBPq9C9Ppn58cg");
+    expect(metadata?.sellerFeeBasisPoints).toEqual(300);
+
+    expect(metadata?.creators?.length).toEqual(4);
+
+    expect(metadata?.creators?.[0]?.address.toString()).toEqual("9aALgDk1Ryx4PQLeeaFRVHpRmR3xUoyFTvR7RVXky23S");
+    expect(metadata?.creators?.[0]?.verified).toEqual(true);
+    expect(metadata?.creators?.[0]?.share).toEqual(0);
+
+    expect(metadata?.creators?.[1]?.address.toString()).toEqual("BPbS1AC4KW5SBiz8M2AgPtWXTzR1ekBwMLLQLcwdvZnE");
+    expect(metadata?.creators?.[1]?.verified).toEqual(false);
+    expect(metadata?.creators?.[1]?.share).toEqual(0);
+
+    expect(metadata?.creators?.[2]?.address.toString()).toEqual("5dNGzQh9sonyFUcTHrH6wiCczokUMSc79miMEysyVYjK");
+    expect(metadata?.creators?.[2]?.verified).toEqual(false);
+    expect(metadata?.creators?.[2]?.share).toEqual(0);
+
+    expect(metadata?.creators?.[3]?.address.toString()).toEqual("E3G6ujBGbusExBAPL5hg62xu5ncWeVh9CLjU9qbusVvs");
+    expect(metadata?.creators?.[3]?.verified).toEqual(false);
+    expect(metadata?.creators?.[3]?.share).toEqual(100);
+
+    expect(metadata?.primarySaleHappened).toEqual(true);
+    expect(metadata?.isMutable).toEqual(true);
+    expect(metadata?.editionNonce).toEqual(255);
+    expect(metadata?.tokenStandard).toEqual(null);
+    expect(metadata?.collection?.verified).toEqual(true);
+    expect(metadata?.collection?.key.toString()).toEqual("Aoz4BEWLkwmWXvujkdjH3ozb61VvqJhtFQ49khXj7Lxi");
+    expect(metadata?.uses).toEqual(null);
+  });
+
+  it("parse onchain metadata 2", () => {
+    const metadata = client.parseOnChainMetadata(publicKey, sampleMetadata2);
+    expect(metadata?.updateAuthority.toString()).toEqual("GfELr1GA9bLmgiMymUm7h8nDkZLG2Ls6txSsANopeVEW");
+    expect(metadata?.mint.toString()).toEqual("8sC7boKrE2v7uebpwruFj2AcRhb98MQm1Ry85PcUuArV");
+    expect(metadata?.name).toEqual("SMB Gen3 #3991");
+    expect(metadata?.symbol).toEqual("");
+    expect(metadata?.uri).toEqual("https://nftstorage.link/ipfs/bafybeifn5xtvstb4u5dkb6uwpp4rmo3p5ftnl5dydcpalfa2rncuyimmmy/3990.json");
+    expect(metadata?.sellerFeeBasisPoints).toEqual(500);
+
+    expect(metadata?.creators?.length).toEqual(4);
+
+    expect(metadata?.creators?.[0]?.address.toString()).toEqual("HV4Nvm9zHfNA43JYYkjZu8vwqiuE8bfEhwcKFfyQ65o5");
+    expect(metadata?.creators?.[0]?.verified).toEqual(true);
+    expect(metadata?.creators?.[0]?.share).toEqual(0);
+
+    expect(metadata?.creators?.[1]?.address.toString()).toEqual("smbBn7Votkw2upiVZtX9WgkmC7fNW2QabfVFuPLhu3C");
+    expect(metadata?.creators?.[1]?.verified).toEqual(false);
+    expect(metadata?.creators?.[1]?.share).toEqual(0);
+
+    expect(metadata?.creators?.[2]?.address.toString()).toEqual("HqqiyJcm3yWPyzwisRKAQa2bJAj14V837yJRGaxwRFaG");
+    expect(metadata?.creators?.[2]?.verified).toEqual(false);
+    expect(metadata?.creators?.[2]?.share).toEqual(88);
+
+    expect(metadata?.creators?.[3]?.address.toString()).toEqual("8vttKbtbXaUcCfJdPNnZjMfKMBCnTXsxy96U4WSLSJHU");
+    expect(metadata?.creators?.[3]?.verified).toEqual(false);
+    expect(metadata?.creators?.[3]?.share).toEqual(12);
+
+    expect(metadata?.primarySaleHappened).toEqual(true);
+    expect(metadata?.isMutable).toEqual(true);
+    expect(metadata?.editionNonce).toEqual(254);
+    expect(metadata?.tokenStandard).toEqual(4);
+    expect(metadata?.collection?.verified).toEqual(true);
+    expect(metadata?.collection?.key.toString()).toEqual("8Rt3Ayqth4DAiPnW9MDFi63TiQJHmohfTWLMQFHi4KZH");
+    expect(metadata?.uses).toEqual(null);
+  });
+
+  it("parse onchain metadata 3", () => {
+    const metadata = client.parseOnChainMetadata(publicKey, sampleMetadata3);
+    expect(metadata?.updateAuthority.toString()).toEqual("79SQqm8SUyLR21cXk5TEGCtkjWnN7NwBjUUY2aYUci8B");
+    expect(metadata?.mint.toString()).toEqual("Aoz4BEWLkwmWXvujkdjH3ozb61VvqJhtFQ49khXj7Lxi");
+    expect(metadata?.name).toEqual("Orcanauts");
+    expect(metadata?.symbol).toEqual("ORCANAUT");
+    expect(metadata?.uri).toEqual("https://arweave.net/u_p9VQ0qQcQJ_veZLvwmu0jd-2tdC6UGjnpvamhfnpc");
+    expect(metadata?.sellerFeeBasisPoints).toEqual(0);
+
+    expect(metadata?.creators?.length).toEqual(1);
+
+    expect(metadata?.creators?.[0]?.address.toString()).toEqual("79SQqm8SUyLR21cXk5TEGCtkjWnN7NwBjUUY2aYUci8B");
+    expect(metadata?.creators?.[0]?.verified).toEqual(true);
+    expect(metadata?.creators?.[0]?.share).toEqual(100);
+
+    expect(metadata?.primarySaleHappened).toEqual(false);
+    expect(metadata?.isMutable).toEqual(true);
+    expect(metadata?.editionNonce).toEqual(255);
+    expect(metadata?.tokenStandard).toEqual(0);
+    expect(metadata?.collection).toEqual(null);
+    expect(metadata?.uses).toEqual(null);
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,139 @@
     bn.js "^5.2.0"
     debug "^4.3.4"
 
+"@metaplex-foundation/mpl-token-metadata@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-3.1.0.tgz#7cace7541eb3bef5d4314a416a478ad889e8acfa"
+  integrity sha512-DbXuijqqhpeXa2ml6A2j38BfK/fG4c8w7vkY/+fBuZP3pOtqhB0/7/CLwXpYF5kWpjtS8FhpGpU91jGt1uzsiQ==
+  dependencies:
+    "@metaplex-foundation/mpl-toolbox" "^0.9.0"
+
+"@metaplex-foundation/mpl-toolbox@^0.9.0":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-toolbox/-/mpl-toolbox-0.9.1.tgz#a4dfcf61fbfc2a02dec49437aa3102c79f3281bd"
+  integrity sha512-Jm98H997MrDfKItjA8bxfsQa+ijVVR6YmMapSd0l75+nKo6Ca0eve/tv2z4qudMS2A4HbH6NLKSW3JHkutzvkQ==
+
+"@metaplex-foundation/umi-bundle-defaults@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-bundle-defaults/-/umi-bundle-defaults-0.8.9.tgz#40765d4a8438d0354cdeb61098ad421432ef5407"
+  integrity sha512-+4FTzYNYJuKUWEE31deKC/3HpAq0o1rJcFlsx7vZgTAX+RTA00QjWVC9VeX8cEyOsZ2E4ZjLBEXBFsSrUaWlEA==
+  dependencies:
+    "@metaplex-foundation/umi-downloader-http" "^0.8.9"
+    "@metaplex-foundation/umi-eddsa-web3js" "^0.8.9"
+    "@metaplex-foundation/umi-http-fetch" "^0.8.9"
+    "@metaplex-foundation/umi-program-repository" "^0.8.9"
+    "@metaplex-foundation/umi-rpc-chunk-get-accounts" "^0.8.9"
+    "@metaplex-foundation/umi-rpc-web3js" "^0.8.9"
+    "@metaplex-foundation/umi-serializer-data-view" "^0.8.9"
+    "@metaplex-foundation/umi-transaction-factory-web3js" "^0.8.9"
+
+"@metaplex-foundation/umi-downloader-http@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-downloader-http/-/umi-downloader-http-0.8.9.tgz#bfe6edd95b406d81fd16c4bde7fdd87d06ea19a6"
+  integrity sha512-iCCNgjXnB9D0coXK4uAB7HrkvUKTOtB/cDBYh79hYXFM69K4Qfy3rJvlyVoRTUKcJCjZEchaxohg74WTeXqLvQ==
+
+"@metaplex-foundation/umi-eddsa-web3js@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-eddsa-web3js/-/umi-eddsa-web3js-0.8.9.tgz#c2579ea86cbe6780753e965842f991793cf4ff4b"
+  integrity sha512-ltaQ5eH73NHOAZ+Qtt5+H+pFbahSSEEzs34tV2trtyr6zrYrawOuHqxvLkiduhdVFe8A05EqQGwFUA6qrx6z9g==
+  dependencies:
+    "@metaplex-foundation/umi-web3js-adapters" "^0.8.9"
+    "@noble/curves" "^1.0.0"
+
+"@metaplex-foundation/umi-http-fetch@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-http-fetch/-/umi-http-fetch-0.8.9.tgz#68367c8aa39e71d30adf25d8570190610fbd5e4a"
+  integrity sha512-gbnW0HrSyt3UlA50TSF2taQTK9/mHUtptd87GZsfmGiEZpnI/LlyZVgfBz7eW8+liwBGN7QarYM3uElyrKlERA==
+  dependencies:
+    node-fetch "^2.6.7"
+
+"@metaplex-foundation/umi-options@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-options/-/umi-options-0.8.9.tgz#9c9e269d9eee7d055ad6831dcb30a30127dcb0c5"
+  integrity sha512-jSQ61sZMPSAk/TXn8v8fPqtz3x8d0/blVZXLLbpVbo2/T5XobiI6/MfmlUosAjAUaQl6bHRF8aIIqZEFkJiy4A==
+
+"@metaplex-foundation/umi-program-repository@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-program-repository/-/umi-program-repository-0.8.9.tgz#f557e14e61dbe65e2fef5e25e2c11f539295e54e"
+  integrity sha512-Q6uNH+zTDiXwsL8l/fhNnCyd9ztblDxCkM8hhPbngHqDhxpedvopWEIopHzmkomngle+biXlPJfb+eQrGygklQ==
+
+"@metaplex-foundation/umi-public-keys@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-public-keys/-/umi-public-keys-0.8.9.tgz#ca7a927c924ed8e28d0f8bb3dc0f2adc1f9011ec"
+  integrity sha512-CxMzN7dgVGOq9OcNCJe2casKUpJ3RmTVoOvDFyeoTQuK+vkZ1YSSahbqC1iGuHEtKTLSjtWjKvUU6O7zWFTw3Q==
+  dependencies:
+    "@metaplex-foundation/umi-serializers-encodings" "^0.8.9"
+
+"@metaplex-foundation/umi-rpc-chunk-get-accounts@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-rpc-chunk-get-accounts/-/umi-rpc-chunk-get-accounts-0.8.9.tgz#2f45fcdcb41edad9ddbffe9a5a1f0482efd96c89"
+  integrity sha512-u6lSSQnp0jApJcBxUegu7o/0NRoe/tvqFkMxCJuK5JMbxeWv3lEd4S/ErkV2dTkZajz7kiCez4r2d+iWc0EqtA==
+
+"@metaplex-foundation/umi-rpc-web3js@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-rpc-web3js/-/umi-rpc-web3js-0.8.9.tgz#594b81f6b80fe7ad9e17dabef13ad39a574b8550"
+  integrity sha512-usG4ty361K8toxL8FcDVeBoQNpSolQwYvHSwsFlMGvfCvi90GVJQwZM/7QXnkr2LJ08Nu6aQiNqX1j+pmCmetw==
+  dependencies:
+    "@metaplex-foundation/umi-web3js-adapters" "^0.8.9"
+
+"@metaplex-foundation/umi-serializer-data-view@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-serializer-data-view/-/umi-serializer-data-view-0.8.9.tgz#91fea7b37fd0d29c8934a6a0bb68efa8ff1460ee"
+  integrity sha512-LRTxq/DjV6dCLBQ9k+rDBOhT/xk2I7tCoVGf/6MQRi1Ps7QTy6oN7BQmR6Cj12YxfSWDm2E1KVHkfSbb1qZOXQ==
+
+"@metaplex-foundation/umi-serializers-core@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-serializers-core/-/umi-serializers-core-0.8.9.tgz#cd5ae763a59e54dd01f1284f4a6bf4e78e4aab9c"
+  integrity sha512-WT82tkiYJ0Qmscp7uTj1Hz6aWQPETwaKLAENAUN5DeWghkuBKtuxyBKVvEOuoXerJSdhiAk0e8DWA4cxcTTQ/w==
+
+"@metaplex-foundation/umi-serializers-encodings@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-serializers-encodings/-/umi-serializers-encodings-0.8.9.tgz#0f02605ee3e6fbeac1abc4fb267a7cc96ecb4410"
+  integrity sha512-N3VWLDTJ0bzzMKcJDL08U3FaqRmwlN79FyE4BHj6bbAaJ9LEHjDQ9RJijZyWqTm0jE7I750fU7Ow5EZL38Xi6Q==
+  dependencies:
+    "@metaplex-foundation/umi-serializers-core" "^0.8.9"
+
+"@metaplex-foundation/umi-serializers-numbers@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-serializers-numbers/-/umi-serializers-numbers-0.8.9.tgz#28c10367f6aebac0276ec1bce81d0d8db54b05de"
+  integrity sha512-NtBf1fnVNQJHFQjLFzRu2i9GGnigb9hOm/Gfrk628d0q0tRJB7BOM3bs5C61VAs7kJs4yd+pDNVAERJkknQ7Lg==
+  dependencies:
+    "@metaplex-foundation/umi-serializers-core" "^0.8.9"
+
+"@metaplex-foundation/umi-serializers@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-serializers/-/umi-serializers-0.8.9.tgz#af6c5bb1a3276cbe252fd08e359b305ed80a3343"
+  integrity sha512-Sve8Etm3zqvLSUfza+MYRkjTnCpiaAFT7VWdqeHzA3n58P0AfT3p74RrZwVt/UFkxI+ln8BslwBDJmwzcPkuHw==
+  dependencies:
+    "@metaplex-foundation/umi-options" "^0.8.9"
+    "@metaplex-foundation/umi-public-keys" "^0.8.9"
+    "@metaplex-foundation/umi-serializers-core" "^0.8.9"
+    "@metaplex-foundation/umi-serializers-encodings" "^0.8.9"
+    "@metaplex-foundation/umi-serializers-numbers" "^0.8.9"
+
+"@metaplex-foundation/umi-transaction-factory-web3js@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-transaction-factory-web3js/-/umi-transaction-factory-web3js-0.8.9.tgz#7ce6d695a9329bd9104855fb36bb0c486be77f9e"
+  integrity sha512-zhO598jmDzaNUJvxapkC5+RfL+eU6RvkIvM4wsc2sfUSE15ekO8Psq/vlzWQXub4ks5TiaBwjSz700+eSlAR1Q==
+  dependencies:
+    "@metaplex-foundation/umi-web3js-adapters" "^0.8.9"
+
+"@metaplex-foundation/umi-web3js-adapters@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi-web3js-adapters/-/umi-web3js-adapters-0.8.9.tgz#5541159e1c69a9c984cde5e7015247dad4af39ea"
+  integrity sha512-WKdWUEiDnoWKKEETy6DjLWyHlMwKi5OPJ6eeApeui6ITkTTAs3z3BAf3NYDYywmN/DgeXPIbJkwwkwfvcHg3xw==
+  dependencies:
+    buffer "^6.0.3"
+
+"@metaplex-foundation/umi@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/umi/-/umi-0.8.9.tgz#474364733b77b9b3dd5bda594776c30657228110"
+  integrity sha512-Gip7HPDCjsX7OakPFBiifX89AofUGcsj/ujbvOfd/6GDIL4XjX79royuT3yyxzovRxyiaPF/kCK6a2dKtm69Kw==
+  dependencies:
+    "@metaplex-foundation/umi-options" "^0.8.9"
+    "@metaplex-foundation/umi-public-keys" "^0.8.9"
+    "@metaplex-foundation/umi-serializers" "^0.8.9"
+
 "@noble/curves@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
@@ -1511,6 +1644,20 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@orca-so/token-sdk@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@orca-so/token-sdk/-/token-sdk-0.1.6.tgz#a479063f01d0597263b47515bf1b5eaa1748ee19"
+  integrity sha512-DRZqOAnkC2OnLlraS32Ydu9WtamkueSjhpraTJZ3qp6h619ci4GCmUVXNyKXL5TqiKiQOdkqbgF7FvE+//G43w==
+  dependencies:
+    "@metaplex-foundation/js" "^0.19.4"
+    "@orca-so/common-sdk" "^0.3.1"
+    "@solana/spl-token" "0.3.8"
+    "@solana/web3.js" "^1.75.0"
+    isomorphic-unfetch "^4.0.2"
+    p-queue "6.6.2"
+    p-timeout "^4.0.0"
+    tiny-invariant "^1.2.0"
 
 "@randlabs/communication-bridge@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
https://app.asana.com/0/0/1205157773161082/f

The dependency `metaplex-foundataion/js` is deprecated. This change replaces the usage of `metaplex-foundataion/js` with `metaplex-foundataion/umi` and `metaplex-foundation/mpl-token-metadata` with functionality staying the same.