### PR TITLE
Adding read only wallet utility class

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/wallet.ts
+++ b/packages/common-sdk/src/web3/wallet.ts
@@ -5,3 +5,16 @@ export interface Wallet {
   signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]>;
   publicKey: PublicKey;
 }
+
+export class ReadOnlyWallet implements Wallet {
+  constructor(public publicKey: PublicKey = PublicKey.default) {}
+
+  signTransaction<T extends Transaction | VersionedTransaction>(_transaction: T): Promise<T> {
+    throw new Error("Read only wallet cannot sign transaction.");
+  }
+  signAllTransactions<T extends Transaction | VersionedTransaction>(
+    _transactions: T[]
+  ): Promise<T[]> {
+    throw new Error("Read only wallet cannot sign transactions.");
+  }
+}


### PR DESCRIPTION
Add `ReadOnlyWallet` utility class to `common-sdk`