### PR TITLE
Add token repository method to clear tags

### DIFF
--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/token-sdk/src/repository.ts
+++ b/packages/token-sdk/src/repository.ts
@@ -108,6 +108,18 @@ export class TokenRepository {
   }
 
   /**
+   * Untags all mints in the repository.
+   * @returns This instance of the repository
+   */
+  clearTags(): TokenRepository {
+    Array.from(this.mintMap.entries()).forEach(([, entry]) => {
+      entry.tags.clear();
+    });
+    this.tagMap.clear();
+    return this;
+  }
+
+  /**
    * Fetches all token metadata and tags for all unexcluded mints in the repository.
    *
    * @param fetcher TokenFetcher to use

--- a/packages/token-sdk/tests/repository.test.ts
+++ b/packages/token-sdk/tests/repository.test.ts
@@ -261,4 +261,23 @@ describe("token-repository", () => {
     repo.tagMint(mint2, ["whitelisted"]);
     expect(repo.has(mint2)).toBeFalsy();
   });
+
+  it("clearTags", async () => {
+    const mints = [mint1, mint2, mint3];
+    const repo = new TokenRepository()
+      .addMints(mints, ["whitelisted"])
+      .addMint(mint1, ["coingecko"]);
+    const whitelisted = await repo.fetchByTag(fetcher, "whitelisted");
+    expect(whitelisted.length).toEqual(3);
+    const coingecko = await repo.fetchByTag(fetcher, "coingecko");
+    expect(coingecko.length).toEqual(1);
+    repo.clearTags();
+
+    expect((await repo.fetchAll(fetcher)).length).toEqual(3);
+    expect((await repo.fetchByTag(fetcher, "whitelisted")).length).toEqual(0);
+    expect((await repo.fetchByTag(fetcher, "coingecko")).length).toEqual(0);
+    expect(repo.has(mint1)).toBeTruthy();
+    expect(repo.has(mint1, "whitelisted")).toBeFalsy();
+    expect((await repo.fetch(fetcher, mint1, true)).tags.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
We ran into an issue where the `TokenRepository` did not handle a mint changing mintlists properly.

Usage of the repository is like the following:
```
      this.repository
        .tagMintlist(defaultList, [Tag.Whitelisted])
        .tagMintlist(extended, [Tag.Whitelisted])
        .tagMintlist(unsupported, [Tag.Unsupported])
        .setOverrides(overrides);
```
Code path that uncovered a bug in usage:
1. Add mint to unsupported mintlist
2. Repository picks up the mint and tags it with the unsupported tag
3. Remove mint from unsupported, add to extended list
4. Repository picks up mint and tags it with the whitelisted tag. However, the unsupported tag was never removed.

This patch adds a `.clearTags()` method which clears all tags in the token repository. This is the proposed usage which should address the error outlined above:
```
      this.repository
        .clearTags()
        .tagMintlist(defaultList, [Tag.Whitelisted])
        .tagMintlist(extended, [Tag.Whitelisted])
        .tagMintlist(unsupported, [Tag.Unsupported])
        .setOverrides(overrides);
```