### PR TITLE
Added a WrappedSolAccountCreateMethod (ata) using syncNative

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/ata-util.ts
+++ b/packages/common-sdk/src/web3/ata-util.ts
@@ -78,7 +78,7 @@ export async function resolveOrCreateATAs(
   payer = ownerAddress,
   modeIdempotent: boolean = false,
   allowPDAOwnerAddress: boolean = false,
-  wrappedSolAccountCreateMethod: WrappedSolAccountCreateMethod = "ata",
+  wrappedSolAccountCreateMethod: WrappedSolAccountCreateMethod = "keypair",
 ): Promise<ResolvedTokenAddressInstruction[]> {
   const nonNativeMints = requests.filter(({ tokenMint }) => !tokenMint.equals(NATIVE_MINT));
   const nativeMints = requests.filter(({ tokenMint }) => tokenMint.equals(NATIVE_MINT));

--- a/packages/common-sdk/src/web3/ata-util.ts
+++ b/packages/common-sdk/src/web3/ata-util.ts
@@ -78,7 +78,7 @@ export async function resolveOrCreateATAs(
   payer = ownerAddress,
   modeIdempotent: boolean = false,
   allowPDAOwnerAddress: boolean = false,
-  wrappedSolAccountCreateMethod: WrappedSolAccountCreateMethod = "keypair",
+  wrappedSolAccountCreateMethod: WrappedSolAccountCreateMethod = "ata",
 ): Promise<ResolvedTokenAddressInstruction[]> {
   const nonNativeMints = requests.filter(({ tokenMint }) => !tokenMint.equals(NATIVE_MINT));
   const nativeMints = requests.filter(({ tokenMint }) => tokenMint.equals(NATIVE_MINT));

--- a/packages/common-sdk/src/web3/ata-util.ts
+++ b/packages/common-sdk/src/web3/ata-util.ts
@@ -143,7 +143,7 @@ export async function resolveOrCreateATAs(
       ownerAddress,
       wrappedSolAmountIn,
       accountRentExempt,
-      undefined, // use default
+      payer,
       undefined, // use default
       wrappedSolAccountCreateMethod
     );

--- a/packages/common-sdk/src/web3/token-util.ts
+++ b/packages/common-sdk/src/web3/token-util.ts
@@ -2,12 +2,14 @@ import {
   AccountLayout,
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountIdempotentInstruction,
   createCloseAccountInstruction,
   createInitializeAccountInstruction,
+  createSyncNativeInstruction,
   createTransferCheckedInstruction,
   getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
-import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey, SystemProgram, TransactionInstruction } from "@solana/web3.js";
 import { sha256 } from '@noble/hashes/sha256';
 import BN from "bn.js";
 import invariant from "tiny-invariant";
@@ -23,7 +25,7 @@ export type ResolvedTokenAddressInstruction = {
 /**
  * @category Util
  */
-export type WrappedSolAccountCreateMethod = "keypair" | "withSeed";
+export type WrappedSolAccountCreateMethod = "keypair" | "withSeed" | "ata";
 
 /**
  * @category Util
@@ -49,14 +51,39 @@ export class TokenUtil {
     rentExemptLamports: number,
     payer?: PublicKey,
     unwrapDestination?: PublicKey,
-    createAccountMethod: WrappedSolAccountCreateMethod = "keypair",
+    createAccountMethod: WrappedSolAccountCreateMethod = "ata",
   ): ResolvedTokenAddressInstruction {
     const payerKey = payer ?? owner;
     const unwrapDestinationKey = unwrapDestination ?? payer ?? owner;
 
-    return createAccountMethod === "keypair"
-      ? createWrappedNativeAccountInstructionWithKeypair(owner, amountIn, rentExemptLamports, payerKey, unwrapDestinationKey)
-      : createWrappedNativeAccountInstructionWithSeed(owner, amountIn, rentExemptLamports, payerKey, unwrapDestinationKey);
+    switch (createAccountMethod) {
+      case "ata":
+        return createWrappedNativeAccountInstructionWithATA(
+          owner,
+          amountIn,
+          rentExemptLamports,
+          payerKey,
+          unwrapDestinationKey
+        );
+      case "keypair":
+        return createWrappedNativeAccountInstructionWithKeypair(
+          owner,
+          amountIn,
+          rentExemptLamports,
+          payerKey,
+          unwrapDestinationKey
+        );
+      case "withSeed":
+        return createWrappedNativeAccountInstructionWithSeed(
+          owner,
+          amountIn,
+          rentExemptLamports,
+          payerKey,
+          unwrapDestinationKey
+        );
+      default:
+        throw new Error(`Invalid createAccountMethod: ${createAccountMethod}`);
+    }
   }
 
   /**
@@ -127,6 +154,53 @@ export class TokenUtil {
       signers: destinationAtaIx.signers,
     };
   }
+}
+
+function createWrappedNativeAccountInstructionWithATA(
+  owner: PublicKey,
+  amountIn: BN,
+  _rentExemptLamports: number,
+  payerKey: PublicKey,
+  unwrapDestinationKey: PublicKey,
+): ResolvedTokenAddressInstruction {
+  const tempAccount = getAssociatedTokenAddressSync(NATIVE_MINT, owner);
+
+  const instructions: TransactionInstruction[] = [];
+
+  const createAccountInstruction = createAssociatedTokenAccountIdempotentInstruction(
+    payerKey,
+    tempAccount,
+    owner,
+    NATIVE_MINT
+  );
+  instructions.push(createAccountInstruction);
+
+  if (amountIn.gt(ZERO)) {
+    const transferInstruction = SystemProgram.transfer({
+      fromPubkey: payerKey,
+      toPubkey: tempAccount,
+      lamports: amountIn.toNumber(),
+    })
+    instructions.push(transferInstruction);
+
+    const syncNativeInstruction = createSyncNativeInstruction(
+      tempAccount,
+    );
+    instructions.push(syncNativeInstruction);
+  }
+
+  const closeWSOLAccountInstruction = createCloseAccountInstruction(
+    tempAccount,
+    unwrapDestinationKey,
+    owner
+  );
+
+  return {
+    address: tempAccount,
+    instructions,
+    cleanupInstructions: [closeWSOLAccountInstruction],
+    signers: [],
+  };
 }
 
 function createWrappedNativeAccountInstructionWithKeypair(

--- a/packages/common-sdk/src/web3/token-util.ts
+++ b/packages/common-sdk/src/web3/token-util.ts
@@ -2,7 +2,7 @@ import {
   AccountLayout,
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
-  createAssociatedTokenAccountIdempotentInstruction,
+  createAssociatedTokenAccountInstruction,
   createCloseAccountInstruction,
   createInitializeAccountInstruction,
   createSyncNativeInstruction,
@@ -167,7 +167,7 @@ function createWrappedNativeAccountInstructionWithATA(
 
   const instructions: TransactionInstruction[] = [];
 
-  const createAccountInstruction = createAssociatedTokenAccountIdempotentInstruction(
+  const createAccountInstruction = createAssociatedTokenAccountInstruction(
     payerKey,
     tempAccount,
     owner,

--- a/packages/common-sdk/src/web3/token-util.ts
+++ b/packages/common-sdk/src/web3/token-util.ts
@@ -51,7 +51,7 @@ export class TokenUtil {
     rentExemptLamports: number,
     payer?: PublicKey,
     unwrapDestination?: PublicKey,
-    createAccountMethod: WrappedSolAccountCreateMethod = "ata",
+    createAccountMethod: WrappedSolAccountCreateMethod = "keypair",
   ): ResolvedTokenAddressInstruction {
     const payerKey = payer ?? owner;
     const unwrapDestinationKey = unwrapDestination ?? owner ?? payer;

--- a/packages/common-sdk/src/web3/token-util.ts
+++ b/packages/common-sdk/src/web3/token-util.ts
@@ -54,7 +54,7 @@ export class TokenUtil {
     createAccountMethod: WrappedSolAccountCreateMethod = "keypair",
   ): ResolvedTokenAddressInstruction {
     const payerKey = payer ?? owner;
-    const unwrapDestinationKey = unwrapDestination ?? owner ?? payer;
+    const unwrapDestinationKey = unwrapDestination ?? owner;
 
     switch (createAccountMethod) {
       case "ata":


### PR DESCRIPTION
This PR adds a third WrappedSolAccountCreateMethod using syncNative instruction. Benefit of this method is that if you don't have to add any sol from the beginning you'd only have 2 instructions (as opposed to 3 with keypair or seed method). This method also does not require an extra signer.