### PR TITLE
Add option to dynamically select compute budget unit price (priority fee) in TransactionBuilder

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -1,0 +1,35 @@
+import { Connection, PublicKey, RecentPrioritizationFees } from "@solana/web3.js";
+import { Instruction } from "./types";
+
+export async function getPriorityFeeInLamports(
+  connection: Connection,
+  computeBudgetLimit: number,
+  instructions: Instruction[],
+): Promise<number> {
+    const recentPriorityFees = await connection.getRecentPrioritizationFees({
+        lockedWritableAccounts: getLockWritableAccounts(instructions),
+    });
+    const priorityFee = getPriorityFeeSuggestion(recentPriorityFees);
+    return (priorityFee * computeBudgetLimit) / 1_000_000;
+}
+
+function getPriorityFeeSuggestion(
+    recentPriorityFees: RecentPrioritizationFees[],
+): number {
+    // Take the 80th percentile of the last 20 slots
+    const sortedPriorityFees = recentPriorityFees
+        .slice(-20)
+        .sort((a, b) => a.prioritizationFee - b.prioritizationFee);
+    const percentileIndex = Math.floor(sortedPriorityFees.length * 0.8);
+    return sortedPriorityFees[percentileIndex].prioritizationFee;
+}
+
+function getLockWritableAccounts(instructions: Instruction[]): PublicKey[] {
+    const accountKeys = instructions
+        .flatMap(instruction => [...instruction.instructions, ...instruction.cleanupInstructions])
+        .flatMap(instruction => instruction.keys);
+    const writableAccounts = accountKeys
+        .filter(key => key.isWritable)
+        .map(key => key.pubkey);
+    return Array.from(new Set(writableAccounts));
+}

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -6,30 +6,26 @@ export async function getPriorityFeeInLamports(
   computeBudgetLimit: number,
   instructions: Instruction[],
 ): Promise<number> {
-    const recentPriorityFees = await connection.getRecentPrioritizationFees({
-        lockedWritableAccounts: getLockWritableAccounts(instructions),
-    });
-    const priorityFee = getPriorityFeeSuggestion(recentPriorityFees);
-    return (priorityFee * computeBudgetLimit) / 1_000_000;
+  const recentPriorityFees = await connection.getRecentPrioritizationFees({
+    lockedWritableAccounts: getLockWritableAccounts(instructions),
+  });
+  const priorityFee = getPriorityFeeSuggestion(recentPriorityFees);
+  return (priorityFee * computeBudgetLimit) / 1_000_000;
 }
 
-function getPriorityFeeSuggestion(
-    recentPriorityFees: RecentPrioritizationFees[],
-): number {
-    // Take the 80th percentile of the last 20 slots
-    const sortedPriorityFees = recentPriorityFees
-        .slice(-20)
-        .sort((a, b) => a.prioritizationFee - b.prioritizationFee);
-    const percentileIndex = Math.floor(sortedPriorityFees.length * 0.8);
-    return sortedPriorityFees[percentileIndex].prioritizationFee;
+function getPriorityFeeSuggestion(recentPriorityFees: RecentPrioritizationFees[]): number {
+  // Take the 80th percentile of the last 20 slots
+  const sortedPriorityFees = recentPriorityFees
+    .slice(-20)
+    .sort((a, b) => a.prioritizationFee - b.prioritizationFee);
+  const percentileIndex = Math.floor(sortedPriorityFees.length * 0.8);
+  return sortedPriorityFees[percentileIndex].prioritizationFee;
 }
 
 function getLockWritableAccounts(instructions: Instruction[]): PublicKey[] {
-    const accountKeys = instructions
-        .flatMap(instruction => [...instruction.instructions, ...instruction.cleanupInstructions])
-        .flatMap(instruction => instruction.keys);
-    const writableAccounts = accountKeys
-        .filter(key => key.isWritable)
-        .map(key => key.pubkey);
-    return Array.from(new Set(writableAccounts));
+  const accountKeys = instructions
+    .flatMap((instruction) => [...instruction.instructions, ...instruction.cleanupInstructions])
+    .flatMap((instruction) => instruction.keys);
+  const writableAccounts = accountKeys.filter((key) => key.isWritable).map((key) => key.pubkey);
+  return Array.from(new Set(writableAccounts));
 }

--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -312,7 +312,10 @@ export class TransactionBuilder {
     let finalComputeBudgetOption = computeBudgetOption ?? { type: "none" };
     if (finalComputeBudgetOption.type === "auto") {
       const computeBudgetLimit = finalComputeBudgetOption.computeBudgetLimit ?? DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
-      const priorityFeeLamports = await getPriorityFeeInLamports(this.connection, computeBudgetLimit, this.instructions);
+      let priorityFeeLamports = await getPriorityFeeInLamports(this.connection, computeBudgetLimit, this.instructions);
+      if (finalComputeBudgetOption.maxPriorityFeeLamports) {
+        priorityFeeLamports = Math.min(priorityFeeLamports, finalComputeBudgetOption.maxPriorityFeeLamports);
+      }
       finalComputeBudgetOption = {
         type: "fixed",
         priorityFeeLamports,


### PR DESCRIPTION
This PR adds automatic priority fee instructions to `TransactionBuilder`. There are a couple of options that can be specified.
* `auto` (with or without a maxPriorityFee) which add a suitable priority fee to the transaction. This only works in `build` and not `buildSync` since it requires an rpc call.
* `fixed` which is just a set amount that a user can specify
* `none` (default) does not add priority fee instructions to the transaction

Since this is set to `{ type: "none" }` updating to this version initially does not change anything. Using this does have some caveats because it prepends two instructions to the transaction. Calling code would have to make sure there is space in the tx for those extra instructions.