### PR TITLE
Fix a bug where priority fees are not sorted correctly to take the last 20 slots

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -16,6 +16,7 @@ export async function getPriorityFeeInLamports(
 function getPriorityFeeSuggestion(recentPriorityFees: RecentPrioritizationFees[]): number {
   // Take the 80th percentile of the last 20 slots
   const sortedPriorityFees = recentPriorityFees
+    .sort((a, b) => a.slot - b.slot)
     .slice(-20)
     .sort((a, b) => a.prioritizationFee - b.prioritizationFee);
   const percentileIndex = Math.floor(sortedPriorityFees.length * 0.8);


### PR DESCRIPTION
getRecentPrioritizationFees rpc method returns the list in an arbitrary order. In order to take the latest 20 slots we need to first sort the list of prioritization fees by slot.