### PR TITLE
Make compute budget priority fee selection more configurable

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -1,6 +1,10 @@
 import { Connection, PublicKey, RecentPrioritizationFees } from "@solana/web3.js";
 import { Instruction } from "./types";
 
+export const MICROLAMPORTS_PER_LAMPORT = 1_000_000;
+export const DEFAULT_PRIORITY_FEE_PERCENTILE = 0.9;
+export const DEFAULT_MAX_PRIORITY_FEE_LAMPORTS = 1000000; // 0.001 SOL
+
 export async function getPriorityFeeInLamports(
   connection: Connection,
   computeBudgetLimit: number,
@@ -11,7 +15,7 @@ export async function getPriorityFeeInLamports(
     lockedWritableAccounts: getLockWritableAccounts(instructions),
   });
   const priorityFee = getPriorityFeeSuggestion(recentPriorityFees, percentile);
-  return (priorityFee * computeBudgetLimit) / 1_000_000;
+  return (priorityFee * computeBudgetLimit) / MICROLAMPORTS_PER_LAMPORT;
 }
 
 function getPriorityFeeSuggestion(recentPriorityFees: RecentPrioritizationFees[], percentile: number): number {

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -5,21 +5,23 @@ export async function getPriorityFeeInLamports(
   connection: Connection,
   computeBudgetLimit: number,
   instructions: Instruction[],
+  percentile: number
 ): Promise<number> {
   const recentPriorityFees = await connection.getRecentPrioritizationFees({
     lockedWritableAccounts: getLockWritableAccounts(instructions),
   });
-  const priorityFee = getPriorityFeeSuggestion(recentPriorityFees);
+  const priorityFee = getPriorityFeeSuggestion(recentPriorityFees, percentile);
   return (priorityFee * computeBudgetLimit) / 1_000_000;
 }
 
-function getPriorityFeeSuggestion(recentPriorityFees: RecentPrioritizationFees[]): number {
-  // Take the 80th percentile of the last 20 slots
+function getPriorityFeeSuggestion(recentPriorityFees: RecentPrioritizationFees[], percentile: number): number {
+  // Take the Xth percentile of all the slots returned
   const sortedPriorityFees = recentPriorityFees
-    .sort((a, b) => a.slot - b.slot)
-    .slice(-20)
     .sort((a, b) => a.prioritizationFee - b.prioritizationFee);
-  const percentileIndex = Math.floor(sortedPriorityFees.length * 0.8);
+  const percentileIndex = Math.min(
+    Math.max(Math.floor(sortedPriorityFees.length * percentile), 0),
+    sortedPriorityFees.length - 1
+  );
   return sortedPriorityFees[percentileIndex].prioritizationFee;
 }
 


### PR DESCRIPTION
Add an option to specify `percentile` for the priority fee suggestion algorithm. It defaults to the 90th percentile but an option like this could be potentially useful if we'd every want to increase or decrease this percentile (which we can then do without having to update this package).