### PR TITLE
Fix TransactionBuilder bug where adding empty ixs caused errors

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -269,7 +269,9 @@ export class TransactionBuilder {
         ...recentBlockhash,
         feePayer: this.wallet.publicKey,
       });
-      transaction.add(...prependInstructions);
+      if (prependInstructions.length > 0) {
+        transaction.add(...prependInstructions);
+      }
       transaction.add(...ix.instructions);
       transaction.feePayer = this.wallet.publicKey;
 


### PR DESCRIPTION
When compute budget options are set to "auto" in `buildSync`, the prepend instructions are empty. Calling `transaction.add()` results in an unhandled exception.