### PR TITLE
PriorityFee instructions (prepend ix-es) are not added when building v0 messages

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -1,20 +1,20 @@
 import {
   AddressLookupTableAccount,
   Commitment,
+  ComputeBudgetProgram,
   Connection,
+  PACKET_DATA_SIZE,
   SendOptions,
   Signer,
   Transaction,
   TransactionInstruction,
   TransactionMessage,
   VersionedTransaction,
-  PACKET_DATA_SIZE,
-  ComputeBudgetProgram,
 } from "@solana/web3.js";
 import { Wallet } from "../wallet";
-import { Instruction, TransactionPayload } from "./types";
-import { MEASUREMENT_BLOCKHASH } from "./constants";
 import { DEFAULT_MAX_PRIORITY_FEE_LAMPORTS, DEFAULT_PRIORITY_FEE_PERCENTILE, MICROLAMPORTS_PER_LAMPORT, getPriorityFeeInLamports } from "./compute-budget";
+import { MEASUREMENT_BLOCKHASH } from "./constants";
+import { Instruction, TransactionPayload } from "./types";
 
 const DEFAULT_MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 
@@ -285,7 +285,7 @@ export class TransactionBuilder {
     const txnMsg = new TransactionMessage({
       recentBlockhash: recentBlockhash.blockhash,
       payerKey: this.wallet.publicKey,
-      instructions: ix.instructions,
+      instructions: [...prependInstructions, ...ix.instructions],
     });
 
     const { lookupTableAccounts } = options;


### PR DESCRIPTION
- Also, bump to 0.5.4