### PR TITLE
Tweak sign order at TransactionProcessor

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",


### PR DESCRIPTION
TransactionProcessor have been deprecated, but it is used in LiquidityTerminal.

Backpack can adjust priority fee setting, but it works for not signed transaction only because partially signed transaction is not rewritable (without signature breaking).

In TransactionProcessor, signing order is signers -> wallet. Signers includes keypair used to create temporary SOL account, etc.  So I'm testing this tweak with X/SOL pool position.

## Without this teak
Backpack cannot rewrite partially signed transaction.
<img width="1409" alt="screenshot 2024-03-21 9 56 32" src="https://github.com/orca-so/orca-sdks/assets/109891005/ac1eb232-7a84-43bc-8aea-cc78e7e6a7c8">

## With this tweak
Backpack cannot rewrite transaction.
<img width="1409" alt="screenshot 2024-03-21 9 57 21" src="https://github.com/orca-so/orca-sdks/assets/109891005/757b26a2-8cec-464c-a1c1-34a77f7ea98e">
