### PR TITLE
Estimate compute budget by simulating transaction

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -23,12 +23,17 @@ export async function estimateComputeBudgetLimit(
 
   const tx = new VersionedTransaction(txMessage);
 
-  const simulation = await connection.simulateTransaction(tx, { sigVerify: false, replaceRecentBlockhash: true });
-  if (!simulation.value.unitsConsumed) {
-    return DEFAULT_MAX_COMPUTE_UNIT_LIMIT
+  try {
+    const simulation = await connection.simulateTransaction(tx, { sigVerify: false, replaceRecentBlockhash: true });
+    if (!simulation.value.unitsConsumed) {
+      return DEFAULT_MAX_COMPUTE_UNIT_LIMIT
+    }
+    const marginUnits = Math.max(100_000, margin * simulation.value.unitsConsumed);
+    const estimatedUnits = Math.ceil(simulation.value.unitsConsumed + marginUnits);
+    return Math.min(DEFAULT_MAX_COMPUTE_UNIT_LIMIT, estimatedUnits);
+  } catch {
+    return DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
   }
-  const marginUnits = Math.max(0, margin) * simulation.value.unitsConsumed;
-  return simulation.value.unitsConsumed + marginUnits;
 }
 
 export async function getPriorityFeeInLamports(

--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -100,7 +100,7 @@ export const defaultTransactionBuilderOptions: TransactionBuilderOptions = {
 export class TransactionBuilder {
   private instructions: Instruction[];
   private signers: Signer[];
-  private opts: TransactionBuilderOptions;
+  readonly opts: TransactionBuilderOptions;
 
   constructor(
     readonly connection: Connection,


### PR DESCRIPTION
In v1.18 the less CUs you request the more prio your tx gets. Starting in 1.18 it is important to not request the max (1.4M) CUs so that your tx can be prioritized accordingly. Added benefit is that you pay less priority fee since they are based on the requested CUs and not the actual CUs consumed.

This PR estimates a compute budget limit by simulating a tx