### PR TITLE
Update `getPriorityFeeInLamports` signature for simplicity

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -39,11 +39,11 @@ export async function estimateComputeBudgetLimit(
 export async function getPriorityFeeInLamports(
   connection: Connection,
   computeBudgetLimit: number,
-  instructions: Instruction[],
-  percentile: number
+  lockedWritableAccounts: PublicKey[],
+  percentile: number = DEFAULT_PRIORITY_FEE_PERCENTILE
 ): Promise<number> {
   const recentPriorityFees = await connection.getRecentPrioritizationFees({
-    lockedWritableAccounts: getLockWritableAccounts(instructions),
+    lockedWritableAccounts,
   });
   const priorityFee = getPriorityFeeSuggestion(recentPriorityFees, percentile);
   return (priorityFee * computeBudgetLimit) / MICROLAMPORTS_PER_LAMPORT;
@@ -60,7 +60,7 @@ function getPriorityFeeSuggestion(recentPriorityFees: RecentPrioritizationFees[]
   return sortedPriorityFees[percentileIndex].prioritizationFee;
 }
 
-function getLockWritableAccounts(instructions: Instruction[]): PublicKey[] {
+export function getLockWritableAccounts(instructions: Instruction[]): PublicKey[] {
   return instructions
     .flatMap((instruction) => [...instruction.instructions, ...instruction.cleanupInstructions])
     .flatMap((instruction) => instruction.keys)

--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -12,7 +12,7 @@ import {
   VersionedTransaction,
 } from "@solana/web3.js";
 import { Wallet } from "../wallet";
-import { DEFAULT_MAX_COMPUTE_UNIT_LIMIT, DEFAULT_MAX_PRIORITY_FEE_LAMPORTS, DEFAULT_PRIORITY_FEE_PERCENTILE, MICROLAMPORTS_PER_LAMPORT, estimateComputeBudgetLimit, getPriorityFeeInLamports } from "./compute-budget";
+import { DEFAULT_MAX_COMPUTE_UNIT_LIMIT, DEFAULT_MAX_PRIORITY_FEE_LAMPORTS, DEFAULT_PRIORITY_FEE_PERCENTILE, MICROLAMPORTS_PER_LAMPORT, estimateComputeBudgetLimit, getLockWritableAccounts, getPriorityFeeInLamports } from "./compute-budget";
 import { MEASUREMENT_BLOCKHASH } from "./constants";
 import { Instruction, TransactionPayload } from "./types";
 
@@ -316,7 +316,7 @@ export class TransactionBuilder {
       const lookupTableAccounts = finalOptions.maxSupportedTransactionVersion === "legacy" ? undefined : finalOptions.lookupTableAccounts;
       const computeBudgetLimit = await estimateComputeBudgetLimit(this.connection, this.instructions, lookupTableAccounts, this.wallet.publicKey, margin);
       const percentile = finalComputeBudgetOption.computePricePercentile ?? DEFAULT_PRIORITY_FEE_PERCENTILE;
-      const priorityFee = await getPriorityFeeInLamports(this.connection, computeBudgetLimit, this.instructions, percentile);
+      const priorityFee = await getPriorityFeeInLamports(this.connection, computeBudgetLimit, getLockWritableAccounts(this.instructions), percentile);
       const maxPriorityFeeLamports = finalComputeBudgetOption.maxPriorityFeeLamports ?? DEFAULT_MAX_PRIORITY_FEE_LAMPORTS;
       const priorityFeeLamports = Math.min(priorityFee, maxPriorityFeeLamports);
       finalComputeBudgetOption = {


### PR DESCRIPTION
This function is relatively new and not used outside of the common-sdk package. This makes it relatively safe to introduce this change to the function signature