### PR TITLE
Release SDKs supporting TE

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.6.0-alpha.3",
+  "version": "0.6.0",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/token-sdk/package.json
+++ b/packages/token-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/token-sdk",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "description": "SPL Token Utilities",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "peerDependencies": {
-    "@orca-so/common-sdk": "^0.6.0-alpha.2",
+    "@orca-so/common-sdk": "^0.6.0",
     "@solana/spl-token": "^0.4.1",
     "@solana/web3.js": "^1.90.0"
   },


### PR DESCRIPTION
Just removed `-alpha.x` 🙂
The backend services & UI have already used alpha version.