### PR TITLE
Add alternate priority fee flow to hardcode priority fee

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.6.0-alpha.3",
+  "version": "0.6.0-alpha.4",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -6,6 +6,7 @@ export const DEFAULT_PRIORITY_FEE_PERCENTILE = 0.9;
 export const DEFAULT_MAX_PRIORITY_FEE_LAMPORTS = 1000000; // 0.001 SOL
 export const DEFAULT_MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 
+// @deprecated
 export async function estimateComputeBudgetLimit(
   connection: Connection,
   instructions: Instruction[],
@@ -41,6 +42,7 @@ export async function estimateComputeBudgetLimitWithSimulation(
   instructions: Instruction[],
   lookupTableAccounts: AddressLookupTableAccount[] | undefined,
   payer: PublicKey,
+  margin: number,
 ): Promise<number> {
   try {
     const txMainInstructions = instructions.flatMap((instruction) => instruction.instructions);
@@ -55,12 +57,14 @@ export async function estimateComputeBudgetLimitWithSimulation(
 
     const simulation = await connection.simulateTransaction(tx, { sigVerify: false, replaceRecentBlockhash: true });
 
-    return simulation.value.unitsConsumed ?? DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
+    const estUnitConsumed = simulation.value.unitsConsumed ?? DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
+    return Math.min(DEFAULT_MAX_COMPUTE_UNIT_LIMIT, Math.ceil(estUnitConsumed * (1 + margin)));
   } catch {
     return DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
   }
 }
 
+// @deprecated
 export async function getPriorityFeeInLamports(
   connection: Connection,
   computeBudgetLimit: number,

--- a/packages/common-sdk/src/web3/transactions/transactions-builder.ts
+++ b/packages/common-sdk/src/web3/transactions/transactions-builder.ts
@@ -67,6 +67,7 @@ type ComputeBudgetOption = {
   computePricePercentile?: number;
 } | {
   type: "auto-fixed-priority";
+  computeLimitMargin?: number;
   priorityFeeMicroLamports: number;
 } | {
   type: "fixed-value";
@@ -345,9 +346,10 @@ export class TransactionBuilder {
     }
 
     if (finalComputeBudgetOption.type === "auto-fixed-priority") {
+      const margin = finalComputeBudgetOption.computeLimitMargin ?? 0.1;
       const priorityFeeMicroLamports = finalComputeBudgetOption.priorityFeeMicroLamports;
       const lookupTableAccounts = finalOptions.maxSupportedTransactionVersion === "legacy" ? undefined : finalOptions.lookupTableAccounts;
-      const computeBudgetLimit = await estimateComputeBudgetLimitWithSimulation(this.connection, this.instructions, lookupTableAccounts, this.wallet.publicKey);
+      const computeBudgetLimit = await estimateComputeBudgetLimitWithSimulation(this.connection, this.instructions, lookupTableAccounts, this.wallet.publicKey, margin);
       finalComputeBudgetOption = {
         type: "fixed-value",
         priorityFeeMicroLamports,


### PR DESCRIPTION
- new computeBudget option `auto-fixed-priority` to allow priority fee hardcoding but with dynamic compute unit estimation
- do away with the 100k w/ margin for compute unit estimation, use the value from simulation directly + margin
