### PR TITLE
Expose custom getRecentPrioritizationFees caller in getPriorityFeeInLamports & ComputeBudgetOption

### DIFF
--- a/packages/common-sdk/package.json
+++ b/packages/common-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/common-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Common Typescript components across Orca",
   "repository": "https://github.com/orca-so/orca-sdks",
   "author": "Orca Foundation",

--- a/packages/common-sdk/src/web3/transactions/compute-budget.ts
+++ b/packages/common-sdk/src/web3/transactions/compute-budget.ts
@@ -41,11 +41,12 @@ export async function getPriorityFeeInLamports(
   connection: Connection,
   computeBudgetLimit: number,
   lockedWritableAccounts: PublicKey[],
-  percentile: number = DEFAULT_PRIORITY_FEE_PERCENTILE
+  percentile: number = DEFAULT_PRIORITY_FEE_PERCENTILE,
+  getRecentPrioritizationFees?: (lockedWritableAccounts: PublicKey[]) => Promise<RecentPrioritizationFees[]>
 ): Promise<number> {
-  const recentPriorityFees = await connection.getRecentPrioritizationFees({
+  const recentPriorityFees = await (getRecentPrioritizationFees ? getRecentPrioritizationFees(lockedWritableAccounts) : connection.getRecentPrioritizationFees({
     lockedWritableAccounts,
-  });
+  }));
   const priorityFee = getPriorityFeeSuggestion(recentPriorityFees, percentile);
   return (priorityFee * computeBudgetLimit) / MICROLAMPORTS_PER_LAMPORT;
 }


### PR DESCRIPTION
- bump to 0.6.3
- expose a `getRecentPrioritizationFees` param in `getPriorityFeeInLamports` so users can explicitly define the RPC call to call `getRecentPrioritizationFees`